### PR TITLE
Close the file and the dir

### DIFF
--- a/include/FatFsSd.h
+++ b/include/FatFsSd.h
@@ -129,6 +129,9 @@ class File {
     FIL fil;
 
    public:
+    ~File() {
+        close();
+    }
     FRESULT open(const TCHAR* path, BYTE mode) { /* Open or create a file */
         return f_open(&fil, path, mode);
     }
@@ -191,6 +194,9 @@ class Dir {
     DIR dir = {};
 
    public:
+    ~Dir() {
+        closedir();
+    }
     FRESULT rewinddir() {
         return f_rewinddir(&dir);
     }


### PR DESCRIPTION
When the File/Dir objects are destroyed, we must close the file/dir otherwise there will be no way to close them again.