### PR TITLE
Make it work on the RP2350

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
-# v3.0.0
+# v3.1.0
 
 ## C/C++ Library for SD Cards on the Pico
 
@@ -11,6 +11,8 @@ and a 4-bit wide Secure Digital Input Output (SDIO) driver derived from
 It is wrapped up in a complete runnable project, with a little command line interface, some self tests, and an example data logging application.
 
 ## What's new
+### v3.1.0
+* Add support for the RP2350
 ### v3.0.0
 * Migrate to **Raspberry Pi Pico SDK 2.0.0**
 * Simplify SPI wait for DMA transfer completion, including elimination of DMA interrupt handler

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "no-OS-FatFS-SD-SDIO-SPI-RPi-Pico",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "Library for SD Cards on the RP2040",
     "keywords": ["Data Storage", "FatFs", "SD card", "Secure Digital card", "SPI", "SDIO"],
     "repository":

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,8 +36,8 @@ target_include_directories(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico INTERFACE
 target_link_libraries(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico INTERFACE
     hardware_dma
     hardware_pio
-    hardware_rtc
     hardware_spi
+    pico_aon_timer
     pico_stdlib
     cmsis_core
 )

--- a/src/include/delays.h
+++ b/src/include/delays.h
@@ -51,7 +51,11 @@ call to millis() returns 0xFFFFFFFF:
 #include <stdint.h>
 //
 #include "pico/stdlib.h"
+#if PICO_RP2040
 #include "RP2040.h"
+#else
+#include "RP2350.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -18,7 +18,11 @@ specific language governing permissions and limitations under the License.
 #include <stdint.h>
 #include <string.h>
 //
+#if PICO_RP2040
 #include "RP2040.h"
+#else
+#include "RP2350.h"
+#endif
 //
 #include "my_debug.h"
 

--- a/src/sd_driver/SDIO/rp2040_sdio.c
+++ b/src/sd_driver/SDIO/rp2040_sdio.c
@@ -15,7 +15,11 @@
 #include "hardware/dma.h"
 #include "hardware/gpio.h"
 #include "hardware/pio.h"
+#if PICO_RP2040
 #include "RP2040.h"
+#else
+#include "RP2350.h"
+#endif
 //
 #include "dma_interrupts.h"
 #include "hw_config.h"

--- a/src/src/my_debug.c
+++ b/src/src/my_debug.c
@@ -17,7 +17,11 @@ specific language governing permissions and limitations under the License.
 #include <stdint.h>
 #include <string.h>
 //
+#if PICO_RP2040
 #include "RP2040.h"
+#else
+#include "RP2350.h"
+#endif
 #include "pico/stdlib.h"
 //
 #include "crash.h"

--- a/src/src/rtc.c
+++ b/src/src/rtc.c
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 */
 #include <time.h>
 //
-#include "hardware/rtc.h"
+#include "pico/aon_timer.h"
 #include "pico/stdio.h"
 #include "pico/stdlib.h"
 #include "pico/util/datetime.h"
@@ -28,33 +28,20 @@ time_t epochtime;
 // Make an attempt to save a recent time stamp across reset:
 typedef struct rtc_save {
     uint32_t signature;
-    datetime_t datetime;
+    struct timespec ts;
     uint32_t checksum;  // last, not included in checksum
 } rtc_save_t;
 static rtc_save_t rtc_save __attribute__((section(".uninitialized_data")));
 
 static void update_epochtime() {
-    bool rc = rtc_get_datetime(&rtc_save.datetime);
-    if (rc) {
-        rtc_save.signature = 0xBABEBABE;
-        struct tm timeinfo = {
-            .tm_sec = rtc_save.datetime
-                          .sec, /* Seconds.	[0-60] (1 leap second) */
-            .tm_min = rtc_save.datetime.min,          /* Minutes.	[0-59] */
-            .tm_hour = rtc_save.datetime.hour,        /* Hours.	[0-23] */
-            .tm_mday = rtc_save.datetime.day,         /* Day.		[1-31] */
-            .tm_mon = rtc_save.datetime.month - 1,    /* Month.	[0-11] */
-            .tm_year = rtc_save.datetime.year - 1900, /* Year	- 1900.  */
-            .tm_wday = 0,                             /* Day of week.	[0-6] */
-            .tm_yday = 0,                             /* Days in year.[0-365]	*/
-            .tm_isdst = -1                            /* DST.		[-1/0/1]*/
-        };
-        rtc_save.checksum = calculate_checksum((uint32_t *)&rtc_save,
-                                               offsetof(rtc_save_t, checksum));
-        epochtime = mktime(&timeinfo);
-        rtc_save.datetime.dotw = timeinfo.tm_wday;
-        // configASSERT(-1 != epochtime);
-    }
+    struct tm timeinfo;
+    aon_timer_get_time(&rtc_save.ts);
+    rtc_save.signature = 0xBABEBABE;
+    localtime_r(&rtc_save.ts.tv_sec, &timeinfo);
+    rtc_save.checksum = calculate_checksum((uint32_t *)&rtc_save,
+                                            offsetof(rtc_save_t, checksum));
+    epochtime = mktime(&timeinfo);
+    // configASSERT(-1 != epochtime);
 }
 
 time_t time(time_t *pxTime) {
@@ -66,50 +53,56 @@ time_t time(time_t *pxTime) {
 }
 
 void time_init() {
-    rtc_init();
-    datetime_t t = {0, 0, 0, 0, 0, 0, 0};
-    rtc_get_datetime(&t);
-    if (!t.year && rtc_save.datetime.year) {
+    struct timespec ts;
+    aon_timer_get_time(&ts);
+
+    struct tm t, t2;
+    localtime_r(&ts.tv_sec, &t);
+    localtime_r(&rtc_save.ts.tv_sec, &t2);
+
+    if (t.tm_year != t2.tm_year) {
         uint32_t xor_checksum = calculate_checksum(
             (uint32_t *)&rtc_save, offsetof(rtc_save_t, checksum));
         if (rtc_save.signature == 0xBABEBABE &&
             rtc_save.checksum == xor_checksum) {
             // Set rtc
-            rtc_set_datetime(&rtc_save.datetime);
+            aon_timer_set_time(&rtc_save.ts);
         }
     }
 }
 
 // Called by FatFs:
 DWORD get_fattime(void) {
-    datetime_t t = {0, 0, 0, 0, 0, 0, 0};
-    bool rc = rtc_get_datetime(&t);
-    if (!rc) return 0;
+    struct timespec ts;
+    aon_timer_get_time(&ts);
+
+    struct tm t;
+    localtime_r(&ts.tv_sec, &t);
 
     DWORD fattime = 0;
     // bit31:25
     // Year origin from the 1980 (0..127, e.g. 37 for 2017)
-    uint8_t yr = t.year - 1980;
+    uint8_t yr = t.tm_year - 1980;
     fattime |= (0b01111111 & yr) << 25;
     // bit24:21
     // Month (1..12)
-    uint8_t mo = t.month;
+    uint8_t mo = t.tm_mon;
     fattime |= (0b00001111 & mo) << 21;
     // bit20:16
     // Day of the month (1..31)
-    uint8_t da = t.day;
+    uint8_t da = t.tm_mday;
     fattime |= (0b00011111 & da) << 16;
     // bit15:11
     // Hour (0..23)
-    uint8_t hr = t.hour;
+    uint8_t hr = t.tm_hour;
     fattime |= (0b00011111 & hr) << 11;
     // bit10:5
     // Minute (0..59)
-    uint8_t mi = t.min;
+    uint8_t mi = t.tm_min;
     fattime |= (0b00111111 & mi) << 5;
     // bit4:0
     // Second / 2 (0..29, e.g. 25 for 50)
-    uint8_t sd = t.sec / 2;
+    uint8_t sd = t.tm_sec / 2;
     fattime |= (0b00011111 & sd);
     return fattime;
 }


### PR DESCRIPTION
The CMSIS includes were hardcoded to RP2040 and had to be changed to include RP2350 where applicable.

Also the RP2350 doesn't have the same RTC as the RP2040, instead it uses a Powman Timer. To adjust for this, the SDK 2.0.0 introduced a new module, the `pico_aon_timer` (Always-On Timer), which uses RTC on the RP2040 and the Powman on the RP2350. See the [2.0.0 release notes](https://github.com/raspberrypi/pico-sdk/releases/tag/2.0.0) for details. 
I changed the RTC-related code to take advantage of this module and have a unified solution for RP2040 and RP2350.

Code verified on HW.