### PR TITLE
v3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
-# v3.0.0
+# v3.1.0
 
 ## C/C++ Library for SD Cards on the Pico
 
@@ -11,15 +11,21 @@ and a 4-bit wide Secure Digital Input Output (SDIO) driver derived from
 It is wrapped up in a complete runnable project, with a little command line interface, some self tests, and an example data logging application.
 
 ## What's new
+### v3.1.0
+* Add `spi_mode` to the hardware configuration.
+For SPI attached cards, SPI Mode 3 can significantly improve performance.
+See [SPI Controller Configuration](#spi-controller-configuration).
+* Make timeouts configurable. See [Timeouts](#timeouts).
+* Add retries in SPI driver `sd_read_blocks`.
 ### v3.0.0
 * Migrate to **Raspberry Pi Pico SDK 2.0.0**
-* Simplify SPI wait for DMA transfer completion, including elimination of DMA interrupt handler
+* Simplify SPI wait for DMA transfer completion, including elimination of DMA interrupt handler.
 For required migration actions, see [Appendix A: Migration actions](#appendix-a-migration-actions).
 ### v2.6.0
-* CRC performance improvements for SPI
+* CRC performance improvements for SPI.
 * Clean up `sd_write_blocks` in `sd_card_spi.c`
 ### v2.5.0
-* Refactor SPI sd_write_blocks
+* Refactor SPI sd_write_blocks.
 * Drop support for SD Standard Capacity Memory Card (up to and including 2 GB). 
 SDSC Card uses byte unit address and SDHC and SDXC Cards (CCS=1) use block unit address (512 Bytes unit).
 ### v2.4.0
@@ -132,12 +138,12 @@ once on SPI and one on SDIO.
     * Transfer rate 12.3 MiB/s (12.9 MB/s), or 12550 KiB/s (12851 kB/s) (102807 kb/s)
 
 * SPI:
-  * Writing
-    * Elapsed seconds 72.9
-    * Transfer rate 2.74 MiB/s (2.88 MB/s), or 2808 KiB/s (2875 kB/s) (23002 kb/s)
-  * Reading
-    * Elapsed seconds 75.9
-    * Transfer rate 2.63 MiB/s (2.76 MB/s), or 2697 KiB/s (2762 kB/s) (22096 kb/s) 
+  * Writing...
+    * Elapsed seconds 68.6
+    * Transfer rate 2.92 MiB/s (3.06 MB/s), or 2986 KiB/s (3057 kB/s) (24458 kb/s)
+  * Reading...
+    * Elapsed seconds 72.7
+    * Transfer rate 2.75 MiB/s (2.88 MB/s), or 2816 KiB/s (2883 kB/s) (23065 kb/s)
 
 Results from a
 [port](https://github.com/carlk3/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/blob/main/examples/command_line/tests/bench.c)
@@ -166,14 +172,14 @@ of
   write speed and latency
   speed,max,min,avg
   KB/Sec,usec,usec,usec
-  2887.0,23936,22497,22663
-  2904.6,23923,22496,22546
+  3160.3,31060,20359,20686
+  3204.7,21576,20338,20418
   ...
   read speed and latency
   speed,max,min,avg
   KB/Sec,usec,usec,usec
-  2778.4,24017,23569,23592
-  2778.4,24018,23569,23587
+  2970.5,22491,22004,22061
+  2970.5,22492,21997,22057
   ...
   ```
 
@@ -521,14 +527,25 @@ typedef struct spi_t {
     uint mosi_gpio;
     uint sck_gpio;
     uint baud_rate;
+
+    /* The different modes of the Motorola SPI protocol are:
+    - Mode 0: When CPOL and CPHA are both 0, data sampled at the leading rising edge of the
+    clock pulse and shifted out on the falling edge. This is the most common mode for SPI bus
+    communication.
+    - Mode 1: When CPOL is 0 and CPHA is 1, data sampled at the trailing falling edge and
+    shifted out on the rising edge.
+    - Mode 2: When CPOL is 1 and CPHA is 0, data sampled at the leading falling edge
+    and shifted out on the rising edge.
+    - Mode 3: When CPOL is 1 and CPHA is 1, data sampled at the trailing rising edge and
+    shifted out on the falling edge. */
+    uint spi_mode;
     bool no_miso_gpio_pull_up;
 
-    /* Drive strength levels for GPIO outputs.
+    /* Drive strength levels for GPIO outputs:
         GPIO_DRIVE_STRENGTH_2MA, 
         GPIO_DRIVE_STRENGTH_4MA, 
         GPIO_DRIVE_STRENGTH_8MA,
-        GPIO_DRIVE_STRENGTH_12MA
-    */
+        GPIO_DRIVE_STRENGTH_12MA */
     bool set_drive_strength;
     enum gpio_drive_strength mosi_gpio_drive_strength;
     enum gpio_drive_strength sck_gpio_drive_strength;
@@ -545,7 +562,7 @@ typedef struct spi_t {
 * `miso_gpio` SPI Master In, Slave Out (MISO) (also called "CIPO" or "Peripheral's SDO") GPIO number. This is connected to the SD card's Data Out (DO).
 * `mosi_gpio` SPI Master Out, Slave In (MOSI) (also called "COPI", or "Peripheral's SDI") GPIO number. This is connected to the SD card's Data In (DI).
 * `sck_gpio` SPI Serial Clock GPIO number. This is connected to the SD card's Serial Clock (SCK).
-* `baud_rate` Frequency of the SPI Serial Clock, in Hertz. The default is 10 MHz.
+* `baud_rate` Frequency of the SPI Serial Clock, in Hertz. The default is `clk_sys` / 12.
   This is ultimately passed to the SDK's [spi_set_baudrate](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#ga37f4c04ce4165ac8c129226336a0b66c). This applies a hardware prescale and a post-divide to the *Peripheral clock* (`clk_peri`) (see section **4.4.2.3.** *Clock prescaler* in [RP2040 Datasheet](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf)). 
   The *Peripheral clock* typically,
   but not necessarily, runs from `clk_sys`.
@@ -558,11 +575,16 @@ typedef struct spi_t {
   ```C
       .baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
   ```
-  If you ask for 14000000, you'll actually get 12500000 Hz.
+  If you ask for 14,000,000 Hz, you'll actually get 12,500,000 Hz.
   The actual baud rate will be printed out if `USE_DBG_PRINTF` (see [Messages from the SD card driver](#messages-from-the-sd-card-driver)) is defined at compile time.
   The higher the baud rate, the faster the data transfer.
-  However, the hardware might limit the usable baud rate.
+  At the maximum `clk_peri` frequency on RP2040 of 133MHz, the maximum peak bit rate in master mode is 62.5Mbps.
+  However, the hardware (including the SD card) might limit the usable baud rate.
   See [Pull Up Resistors and other electrical considerations](#pull-up-resistors-and-other-electrical-considerations).
+* `spi_mode` 0, 1, 2, or 3. 0 is the most common mode for SPI bus slave communication.
+This controls the Motorola SPI frame format CPOL, clock polarity; and CPHA, clock phase.
+SPI mode 0 (CPOL=0, CPHA=0) is the proper setting to control MMC/SDC, but mode 3 (CPOL=1, CPHA=1) also works as well in most cases[^6].
+Mode 3 can be around 15% faster than mode 0, probably due to quirks of the ARM PrimeCell Synchronous Serial Port in the RP2040.
 * `no_miso_gpio_pull_up` According to the standard, an SD card's DO MUST be pulled up (at least for the old MMC cards). 
 However, it might be done externally. If `no_miso_gpio_pull_up` is false, the library will set the RP2040 GPIO internal pull up.
 * `set_drive_strength` Specifies whether or not to set the RP2040 GPIO pin drive strength.
@@ -586,7 +608,7 @@ If `set_drive_strength` is true, each GPIO's drive strength can be set individua
 If false, two DMA channels will be claimed with `dma_claim_unused_channel`.
 * `tx_dma` The DMA channel to use for SPI TX. Ignored if `dma_claim_unused_channel` is false
 * `rx_dma` The DMA channel to use for SPI RX. Ignored if `dma_claim_unused_channel` is false
-### You must provide a definition for the functions declared in `sd_driver/hw_config.h`:  
+### You must provide a definition for the functions declared in `sd_driver/hw_config.h`
 * `size_t sd_get_num()` Returns the number of SD cards  
 * `sd_card_t *sd_get_by_num(size_t num)` Returns a pointer to the SD card "object" at the given
 [physical drive number](http://elm-chan.org/fsw/ff/doc/filename.html#vol).
@@ -600,7 +622,7 @@ In either case, the application simply provides an implementation of the functio
 * See `dynamic_config_example/hw_config.cpp` for an example of dynamic configuration.
 * One advantage of static configuration is that the fantastic GNU Linker (ld) strips out anything that you don't use.
 
-## Customizing the *FatFs - Generic FAT Filesystem Module*
+### Customizing the *FatFs - Generic FAT Filesystem Module*
 There are many options to configure the features of FatFs for various requirements of each project. 
 The configuration options are defined in `ffconf.h`. 
 See [Configuration Options](http://elm-chan.org/fsw/ff/doc/config.html).
@@ -616,6 +638,22 @@ target_include_directories(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico BEFORE INTERFACE
 )
 ```
 For an example, see `examples/unix_like`.
+
+### Timeouts
+Indefinite timeouts are normally bad practice, because they make it difficult to recover from an error.
+Therefore, we have timeouts all over the place.
+To make these configurable, they are collected in `sd_timeouts_t sd_timeouts` in `sd_timeouts.c`.
+The definition has the `weak` attribute, so it can be overridden by user code.
+For example, in `hw_config.c` you could have:
+```C
+sd_timeouts_t sd_timeouts = {
+    .sd_command = 2000, // Timeout in ms for response
+    .sd_command_retries = 3, // Times SPI cmd is retried when there is no response
+//...
+    .sd_sdio_begin = 1000, // Timeout in ms for response
+    .sd_sdio_stopTransmission = 200, // Timeout in ms for response
+};
+```
 
 ## Using the Application Programming Interface
 After `stdio_init_all()`, `time_init()`, and whatever other Pico SDK initialization is required, 
@@ -1028,10 +1066,13 @@ or
 
 ## Appendix D: Performance Tuning Tips
 Obviously, if possible, use 4-bit SDIO instead of 1-bit SPI.
-(See [Choosing the Interface Type(s)](#choosing-the-interface-types)).
+(See [Choosing the Interface Type(s)](#choosing-the-interface-types).)
 
 Obviously, set the baud rate as high as you can. (See
 [Customizing for the Hardware Configuration](#customizing-for-the-hardware-configuration)).
+
+If you are using SPI, try SPI mode 3 (CPOL=1, CPHA=1) instead of 0 (CPOL=0, CPHA=0). (See
+[SPI Controller Configuration](#spi-controller-configuration).) This could buy a 15% speed boost.
 
 TL;DR: In general, it is much faster to transfer a given number of bytes in one large write (or read) 
 than to transfer the same number of bytes in multiple smaller writes (or reads). 
@@ -1143,8 +1184,14 @@ You can swap the commenting to enable tracing of what's happening in that file.
 * Better yet, go to somwhere like [JLCPCB](https://jlcpcb.com/) and get a printed circuit board!
 
 [^1]: as of [Pull Request #12 Dynamic configuration](https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico/pull/12) (in response to [Issue #11 Configurable GPIO pins](https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico/issues/11)), Sep 11, 2021
+
 [^2]: as of [Pull Request #5 Bug in ff_getcwd when FF_VOLUMES < 2](https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico/pull/5), Aug 13, 2021
-[^3]: In my experience, the Card Detect switch on these doesn't work worth a damn. This might not be such a big deal, because according to [Physical Layer Simplified Specification](https://www.sdcard.org/downloads/pls/) the Chip Select (CS) line can be used for Card Detection: "At power up this line has a 50KOhm pull up enabled in the card... For Card detection, the host detects that the line is pulled high." 
+
+[^3]: In my experience, the Card Detect switch on these doesn't work worth a damn. This might not be such a big deal, because according to [Physical Layer Simplified Specification](https://www.sdcard.org/downloads/pls/) the Chip Select (CS) line can be used for Card Detection: "At power up this line has a 50KOhm pull up enabled in the card... For Card detection, the host detects that the line is pulled high."
 However, the Adafruit card has it's own 47 kΩ pull up on CS - Card Detect / Data Line [Bit 3], rendering it useless for Card Detection.
+
 [^4]: [Physical Layer Simplified Specification](https://www.sdcard.org/downloads/pls/)
+
 [^5]: Rationale: Instances of `sd_spi_if_t` or `sd_sdio_if_t` are separate objects instead of being embedded in `sd_card_t` objects because `sd_sdio_if_t` carries a lot of state information with it (including things like data buffers). The union of the two types has the size of the largest type, which would result in a lot of wasted space in instances of `sd_spi_if_t`. I had another solution using `malloc`, but some people are frightened of `malloc` in embedded systems.
+
+[^6]: *SPI Mode* in [How to Use MMC/SDC](http://elm-chan.org/docs/mmc/mmc_e.html#spimode)

--- a/examples/command_line/config/dev_brd.hw_config.c
+++ b/examples/command_line/config/dev_brd.hw_config.c
@@ -40,6 +40,8 @@ tab "Dev Brd", for pin assignments assumed in this configuration file.
 
 #include <assert.h>
 //
+#include "my_debug.h"
+//
 #include "hw_config.h"
 
 // Hardware Configuration of SPI "objects"

--- a/examples/command_line/config/exp_mod_A_SPI.hw_config.c
+++ b/examples/command_line/config/exp_mod_A_SPI.hw_config.c
@@ -37,9 +37,11 @@ static spi_t spi  = {  // One for each RP2040 SPI component used
     .mosi_gpio_drive_strength = GPIO_DRIVE_STRENGTH_4MA,
     .sck_gpio_drive_strength = GPIO_DRIVE_STRENGTH_2MA,
     .no_miso_gpio_pull_up = true,
-    // .baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
+    .spi_mode = 3,
+    //.baud_rate = 125 * 1000 * 1000 / 8  // 15625000 Hz
     //.baud_rate = 125 * 1000 * 1000 / 6  // 20833333 Hz
     .baud_rate = 125 * 1000 * 1000 / 4  // 31250000 Hz
+    //.baud_rate = 125 * 1000 * 1000 / 2  // 62500000 Hz
 };
 
 /* SPI Interface */

--- a/examples/command_line/main.cpp
+++ b/examples/command_line/main.cpp
@@ -1,9 +1,9 @@
 #include <stdio.h>
 //
-#include "pico/stdlib.h"
 #include "hardware/clocks.h"
 #include "hardware/gpio.h"
-//
+#include "pico/stdio.h"
+#include "pico/stdlib.h"
 #include "pico/stdlib.h"
 //
 #include "command.h"

--- a/examples/command_line/tests/big_file_test.c
+++ b/examples/command_line/tests/big_file_test.c
@@ -21,6 +21,7 @@ specific language governing permissions and limitations under the License.
 #include <string.h>
 //
 #include "pico/stdlib.h"
+#include "pico/types.h"
 //
 #include "f_util.h"
 #include "my_debug.h"
@@ -185,6 +186,7 @@ void big_file_test(char *pathname, size_t size_MiB, uint32_t seed) {
     //  /* Working buffer */
     DWORD *buff = malloc(BUFFSZ);
     myASSERT(buff);
+    if (!buff) abort();
     myASSERT(size_MiB);
     if (4095 < size_MiB) {
         EMSG_PRINTF("Warning: Maximum file size: 2^32 - 1 bytes on FAT volume\n");

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/src/glue.c
     ${CMAKE_CURRENT_LIST_DIR}/src/my_debug.c
     ${CMAKE_CURRENT_LIST_DIR}/src/rtc.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/sd_timeouts.c
     ${CMAKE_CURRENT_LIST_DIR}/src/util.c
 )
 target_include_directories(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico INTERFACE

--- a/src/include/crc.h
+++ b/src/include/crc.h
@@ -34,10 +34,19 @@ specific language governing permissions and limitations under the License.
 #include <stddef.h>
 #include <stdint.h>
 
+/**
+ * @brief Calculate the CRC7 checksum for the specified data block.
+ * 
+ * This function calculates the CRC7 checksum for the specified data block
+ * using the lookup table defined in the m_Crc7Table array.
+ * 
+ * @param data The data block to be checked.
+ * @param length The length of the data block in bytes.
+ * @return The calculated checksum.
+ */
+__attribute__((optimize("Ofast")))
+static inline char crc7(uint8_t const *data, int const length) {
 extern const char m_Crc7Table[];    
-__attribute__((optimize("O3")))
-static inline char crc7(const uint8_t* data, int length) {
-	//Calculate the CRC7 checksum for the specified data block
 	char crc = 0;
 	for (int i = 0; i < length; i++) {
 		crc = m_Crc7Table[(crc << 1) ^ data[i]];
@@ -47,8 +56,17 @@ static inline char crc7(const uint8_t* data, int length) {
 	return crc;
 }
 
-unsigned short crc16(uint8_t * data, int length);
-
+/**
+ * @brief Calculate the CRC16 checksum for the specified data block.
+ * 
+ * This function calculates the CRC16 checksum for the specified data block
+ * using the lookup table defined in the m_Crc7Table array.
+ * 
+ * @param data The data block to be checked.
+ * @param length The length of the data block in bytes.
+ * @return The calculated checksum.
+ */
+uint16_t crc16(uint8_t const *data, int const length);
 
 #endif
 

--- a/src/include/my_debug.h
+++ b/src/include/my_debug.h
@@ -22,12 +22,6 @@ specific language governing permissions and limitations under the License.
 extern "C" {
 #endif
 
-#ifdef ANALYZER
-#define TRIG() gpio_put(15, 1)  // DEBUG
-#else
-#define TRIG()
-#endif
-
 /* USE_PRINTF
 If this is defined and not zero,
 these message output functions will use the Pico SDK's stdout.
@@ -60,7 +54,7 @@ int error_message_printf_plain(const char *fmt, ...) __attribute__((format(__pri
 int debug_message_printf(const char *func, int line, const char *fmt, ...)
     __attribute__((format(__printf__, 3, 4)));
 #ifndef DBG_PRINTF
-#  if defined(USE_DBG_PRINTF) && USE_DBG_PRINTF && !defined(NDEBUG)
+#  if defined(USE_DBG_PRINTF) && USE_DBG_PRINTF // && !defined(NDEBUG)
 #    define DBG_PRINTF(fmt, ...) debug_message_printf(__func__, __LINE__, fmt, ##__VA_ARGS__)
 #  else
 #    define DBG_PRINTF(fmt, ...) (void)0
@@ -77,8 +71,12 @@ void unlock_printf();
 
 void my_assert_func(const char *file, int line, const char *func, const char *pred)
     __attribute__((noreturn));
-#define myASSERT(__e) \
+#ifdef NDEBUG           /* required by ANSI standard */
+#  define myASSERT(__e) ((void)0)
+#else
+#  define myASSERT(__e) \
     { ((__e) ? (void)0 : my_assert_func(__func__, __LINE__, __func__, #__e)); }
+#endif    
 
 void assert_always_func(const char *file, int line, const char *func, const char *pred)
     __attribute__((noreturn));
@@ -100,10 +98,8 @@ void assert_case_not_func(const char *file, int line, const char *func, int v)
 #define DBG_ASSERT_CASE_NOT(__v) (assert_case_not_func(__FILE__, __LINE__, __func__, __v))
 #endif
 static inline void dump_bytes(size_t num, uint8_t bytes[]) {
-#if !DBG_PRINTF
     (void)num;
     (void)bytes;
-#else
     DBG_PRINTF("     ");
     for (size_t j = 0; j < 16; ++j) {
         DBG_PRINTF("%02hhx", j);
@@ -125,7 +121,6 @@ static inline void dump_bytes(size_t num, uint8_t bytes[]) {
         }
     }
     DBG_PRINTF("\n");
-#endif
 }
 
 void dump8buf(char *buf, size_t buf_sz, uint8_t *pbytes, size_t nbytes);

--- a/src/include/sd_timeouts.h
+++ b/src/include/sd_timeouts.h
@@ -1,0 +1,23 @@
+
+#pragma once
+
+#include <stdint.h>
+
+typedef struct {
+    uint32_t sd_command;
+    unsigned sd_command_retries;
+    unsigned sd_lock;
+    unsigned sd_spi_read;
+    unsigned sd_spi_write;
+    unsigned sd_spi_write_read;
+    unsigned spi_lock;
+    unsigned rp2040_sdio_command_R1;
+    unsigned rp2040_sdio_command_R2;
+    unsigned rp2040_sdio_command_R3;
+    unsigned rp2040_sdio_rx_poll;
+    unsigned rp2040_sdio_tx_poll;
+    unsigned sd_sdio_begin;
+    unsigned sd_sdio_stopTransmission;
+} sd_timeouts_t;
+
+extern sd_timeouts_t sd_timeouts;

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -18,8 +18,6 @@ specific language governing permissions and limitations under the License.
 #include <stdint.h>
 #include <string.h>
 //
-#include "RP2040.h"
-//
 #include "my_debug.h"
 
 #ifdef __cplusplus

--- a/src/sd_driver/SDIO/rp2040_sdio.c
+++ b/src/sd_driver/SDIO/rp2040_sdio.c
@@ -23,6 +23,7 @@
 #include "rp2040_sdio.pio.h"
 #include "delays.h"
 #include "sd_card.h"
+#include "sd_timeouts.h"
 #include "my_debug.h"
 #include "util.h"
 //
@@ -82,7 +83,7 @@ static const uint8_t crc7_table[256] = {
 // When the SDIO bus operates in 4-bit mode, the CRC16 algorithm
 // is applied to each line separately and generates total of
 // 4 x 16 = 64 bits of checksum.
-__attribute__((optimize("O3")))
+__attribute__((optimize("Ofast")))
 uint64_t sdio_crc16_4bit_checksum(uint32_t *data, uint32_t num_words)
 {
     uint64_t crc = 0;
@@ -167,7 +168,7 @@ sdio_status_t rp2040_sdio_command_R1(sd_card_t *sd_card_p, uint8_t command, uint
     uint32_t wait_words = response ? 2 : 1;
     while (pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_CMD_SM) < wait_words)
     {
-        if ((uint32_t)(millis() - start) > 5)
+        if ((uint32_t)(millis() - start) > sd_timeouts.rp2040_sdio_command_R1)
         {
             if (command != 8) // Don't log for missing SD card
             {
@@ -244,7 +245,7 @@ sdio_status_t rp2040_sdio_command_R2(const sd_card_t *sd_card_p, uint8_t command
     uint32_t start = millis();
     while (dma_channel_is_busy(SDIO_DMA_CH))
     {
-        if ((uint32_t)(millis() - start) > 2)
+        if ((uint32_t)(millis() - start) > sd_timeouts.rp2040_sdio_command_R2)
         {
             azdbg("Timeout waiting for response in rp2040_sdio_command_R2(", (int)command, "), ",
                   "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_CMD_SM) - (int)STATE.pio_cmd_clk_offset,
@@ -311,7 +312,7 @@ sdio_status_t rp2040_sdio_command_R3(sd_card_t *sd_card_p, uint8_t command, uint
     uint32_t start = millis();
     while (pio_sm_get_rx_fifo_level(SDIO_PIO, SDIO_CMD_SM) < 2)
     {
-        if ((uint32_t)(millis() - start) > 2)
+        if ((uint32_t)(millis() - start) > sd_timeouts.rp2040_sdio_command_R3)
         {
             azdbg("Timeout waiting for response in rp2040_sdio_command_R3(", (int)command, "), ",
                   "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_CMD_SM) - (int)STATE.pio_cmd_clk_offset,
@@ -466,7 +467,7 @@ sdio_status_t rp2040_sdio_rx_poll(sd_card_t *sd_card_p, size_t block_size_words)
         else
             return SDIO_ERR_DATA_CRC;
     }
-    else if (millis() - STATE.transfer_start_time >= 1000)
+    else if (millis() - STATE.transfer_start_time >= sd_timeouts.rp2040_sdio_rx_poll)
     {
         azdbg("rp2040_sdio_rx_poll() timeout, "
             "PIO PC: ", (int)pio_sm_get_pc(SDIO_PIO, SDIO_DATA_SM) - (int)STATE.pio_data_rx_offset,
@@ -697,7 +698,7 @@ sdio_status_t rp2040_sdio_tx_poll(sd_card_t *sd_card_p, uint32_t *bytes_complete
         rp2040_sdio_stop(sd_card_p);
         return STATE.wr_status;
     }
-    else if (millis() - STATE.transfer_start_time >= 5000)  // CK3: increased timeout
+    else if (millis() - STATE.transfer_start_time >= sd_timeouts.rp2040_sdio_tx_poll)
     {
         EMSG_PRINTF("rp2040_sdio_tx_poll() timeout\n");
         DBG_PRINTF("rp2040_sdio_tx_poll() timeout, "

--- a/src/sd_driver/SDIO/sd_card_sdio.c
+++ b/src/sd_driver/SDIO/sd_card_sdio.c
@@ -28,6 +28,7 @@
 #include "rp2040_sdio.pio.h"  // build\build\rp2040_sdio.pio.h
 #include "sd_card_constants.h"
 #include "sd_card.h"
+#include "sd_timeouts.h"
 #include "SdioCard.h"
 #include "util.h"
 
@@ -129,7 +130,7 @@ bool sd_sdio_begin(sd_card_t *sd_card_p)
             return false;
         }
 
-        if ((uint32_t)(millis() - start) > 1000)
+        if ((uint32_t)(millis() - start) > sd_timeouts.sd_sdio_begin)
         {
             EMSG_PRINTF("SDIO card initialization timeout\n");
             return false;

--- a/src/sd_driver/SPI/my_spi.c
+++ b/src/sd_driver/SPI/my_spi.c
@@ -13,10 +13,17 @@ specific language governing permissions and limitations under the License.
 */
 
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
 //
+#include "hardware/clocks.h"
+#include "hardware/structs/clocks.h"
+#include "hardware/spi.h"
+#include "pico.h"
+#include "pico/mutex.h"
+#include "pico/platform.h"
 #include "pico/stdlib.h"
 //
-#include "pico/mutex.h"
 #include "delays.h"
 #include "hw_config.h"
 #include "my_debug.h"
@@ -24,28 +31,91 @@ specific language governing permissions and limitations under the License.
 //
 #include "my_spi.h"
 
-#ifdef NDEBUG
-#  pragma GCC diagnostic ignored "-Wunused-variable"
+#ifndef USE_DBG_PRINTF
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
+static bool chk_spi(spi_t *spi_p) {
+    spi_inst_t *hw_spi = spi_p->hw_inst;
+    bool ok = true;
+    if (spi_get_const_hw(hw_spi)->sr & SPI_SSPSR_BSY_BITS) {
+        DBG_PRINTF("SPI is busy\n");
+        ok = false;
+    }
+    if (spi_get_const_hw(hw_spi)->sr & SPI_SSPSR_RFF_BITS) {
+        DBG_PRINTF("SPI Receive FIFO full\n");
+        ok = false;
+    }
+    if (spi_get_const_hw(hw_spi)->sr & SPI_SSPSR_RNE_BITS) {
+        DBG_PRINTF("SPI Receive FIFO not empty\n");
+        ok = false;
+    }
+    if (!(spi_get_const_hw(hw_spi)->sr & SPI_SSPSR_TNF_BITS)) {
+        DBG_PRINTF("SPI Transmit FIFO is full\n");
+        ok = false;
+    }
+    if (!(spi_get_const_hw(hw_spi)->sr & SPI_SSPSR_TFE_BITS)) {
+        DBG_PRINTF("SPI Transmit FIFO is not empty\n");
+        ok = false;
+    }
+    return ok;
+}
+
+static bool chk_dma(uint chn) {
+    dma_channel_hw_t *channel = &dma_hw->ch[chn];
+    bool ok = true;
+    uint32_t ctrl = channel->ctrl_trig;
+    if (ctrl & DMA_CH0_CTRL_TRIG_AHB_ERROR_BITS) {
+        DBG_PRINTF("\tDMA bus error\n");
+        ok = false;
+    }
+    if (ctrl & DMA_CH0_CTRL_TRIG_READ_ERROR_BITS) {
+        DBG_PRINTF("\tDMA read error\n");
+        ok = false;
+    }
+    if (ctrl & DMA_CH0_CTRL_TRIG_WRITE_ERROR_BITS) {
+        DBG_PRINTF("\tDMA write error\n");
+        ok = false;
+    }
+    if (ctrl & DMA_CH0_CTRL_TRIG_BUSY_BITS) {
+        DBG_PRINTF("\tDMA is busy\n");
+        ok = false;
+    }
+    if (!ok) {
+        dma_debug_channel_hw_t *dbg_ch_p = &dma_debug_hw->ch[chn];
+        DBG_PRINTF("\tTRANSFER_COUNT: %lu\n", channel->transfer_count);
+        DBG_PRINTF("\tTRANS_COUNT reload value (DBG_TCR): %lu\n", dbg_ch_p->dbg_tcr);
+        DBG_PRINTF("\tDREQ counter: %lu\n", dbg_ch_p->dbg_ctdreq);
+    }
+    return ok;
+}
+
+static bool chk_dmas(spi_t *spi_p) {
+    bool tx_ok = chk_dma(spi_p->tx_dma);
+    if (!tx_ok) DBG_PRINTF("TX DMA error\n");
+    bool rx_ok = chk_dma(spi_p->rx_dma);
+    if (!rx_ok) DBG_PRINTF("RX DMA error\n");
+    return tx_ok && rx_ok;
+}
+
 /**
- * Starts a SPI transfer by configuring and starting the DMA channels.
+ * @brief Start a SPI transfer by configuring and starting the DMA channels.
  *
  * @param spi_p Pointer to the SPI object.
  * @param tx Pointer to the transmit buffer. If NULL, data will be filled with SPI_FILL_CHAR.
  * @param rx Pointer to the receive buffer. If NULL, data will be ignored.
  * @param length Length of the transfer.
  */
-void spi_transfer_start(spi_t *spi_p, const uint8_t *tx, uint8_t *rx, size_t length) {
-    // myASSERT(512 == length || 1 == length);
+void __not_in_flash_func(spi_transfer_start)(spi_t *spi_p, const uint8_t *tx, uint8_t *rx,
+                                             size_t length) {
+    myASSERT(spi_p);
     myASSERT(tx || rx);
-    // myASSERT(!(tx && rx));
 
     // tx write increment is already false
     if (tx) {
         channel_config_set_read_increment(&spi_p->tx_dma_cfg, true);
     } else {
-        static const uint8_t dummy = SPI_FILL_CHAR;
+        static const uint8_t dummy __attribute__((section(".time_critical."))) = SPI_FILL_CHAR;
         tx = &dummy;
         channel_config_set_read_increment(&spi_p->tx_dma_cfg, false);
     }
@@ -71,35 +141,39 @@ void spi_transfer_start(spi_t *spi_p, const uint8_t *tx, uint8_t *rx, size_t len
                                                             // size transfer_data_size)
                           false);                           // start
 
+    myASSERT(chk_dmas(spi_p));
+    myASSERT(chk_spi(spi_p));
+
+    // Start the DMA channels:
     // start them exactly simultaneously to avoid races (in extreme cases
     // the FIFO could overflow)
     dma_start_channel_mask((1u << spi_p->tx_dma) | (1u << spi_p->rx_dma));
 }
 
-static bool chk_spi(spi_inst_t *spi_p) {
-    bool rc = true;
+/**
+ * Calculate the time in milliseconds to transfer the given number of blocks
+ * over the SPI bus at the given baud rate.
+ * @param block_count The number of blocks to transfer, each 512 bytes.
+ * @param spi_p Pointer to the SPI object.
+ * @return The time in milliseconds to transfer the given number of blocks.
+ */
+uint32_t calculate_transfer_time_ms(spi_t *spi_p, uint32_t bytes) {
+    // Calculate the total number of bits to transfer
+    uint32_t total_bits = bytes * 8;
 
-    if (spi_get_const_hw(spi_p)->sr & SPI_SSPSR_BSY_BITS) {
-        DBG_PRINTF("\tSPI is busy\n");
-        rc = false;
-    }
-    if (spi_get_const_hw(spi_p)->sr & SPI_SSPSR_RFF_BITS) {
-        DBG_PRINTF("\tSPI Receive FIFO full\n");
-        rc = false;
-    }
-    if (spi_get_const_hw(spi_p)->sr & SPI_SSPSR_RNE_BITS) {
-        DBG_PRINTF("\tSPI Receive FIFO not empty\n");
-        rc = false;
-    }
-    if (!(spi_get_const_hw(spi_p)->sr & SPI_SSPSR_TNF_BITS)) {
-        DBG_PRINTF("\tSPI Transmit FIFO is full\n");
-        rc = false;
-    }
-    if (!(spi_get_const_hw(spi_p)->sr & SPI_SSPSR_TFE_BITS)) {
-        DBG_PRINTF("\tSPI Transmit FIFO is not empty\n");
-        rc = false;
-    }
-    return rc;
+    // Get the baud rate from the SPI interface
+    uint32_t baud_rate = spi_get_baudrate(spi_p->hw_inst);
+
+    // Calculate the time to transfer all bits in seconds
+    float transfer_time_sec = (double)total_bits / baud_rate;
+
+    // Convert the time to milliseconds
+    float transfer_time_ms = transfer_time_sec * 1000;
+
+    transfer_time_ms *= 1.5f;  // Add 50% for overhead
+    transfer_time_ms += 4.0f;  // For fixed overhead
+
+    return (uint32_t)transfer_time_ms;
 }
 
 /**
@@ -113,20 +187,20 @@ static bool chk_spi(spi_inst_t *spi_p) {
  * @param timeout_ms The timeout in milliseconds.
  * @return true if the transfer is complete, false if the timeout is reached.
  */
-bool spi_transfer_wait_complete(spi_t *spi_p, uint32_t timeout_ms) {
+bool __not_in_flash_func(spi_transfer_wait_complete)(spi_t *spi_p, uint32_t timeout_ms) {
+    myASSERT(spi_p);
+    bool timed_out = false;
+
     // Record the start time in milliseconds
     uint32_t start = millis();
 
     // Wait until DMA channels are not busy or timeout is reached
-    do {
+    while ((dma_channel_is_busy(spi_p->rx_dma) || dma_channel_is_busy(spi_p->tx_dma)) &&
+           millis() - start < timeout_ms)
         tight_loop_contents();
-    } while ((dma_channel_is_busy(spi_p->rx_dma) ||
-              dma_channel_is_busy(spi_p->tx_dma)) &&
-             millis() - start < timeout_ms);
 
     // Check if the DMA channels are still busy
-    bool timed_out = dma_channel_is_busy(spi_p->rx_dma) ||
-                     dma_channel_is_busy(spi_p->tx_dma);
+    timed_out = dma_channel_is_busy(spi_p->rx_dma) || dma_channel_is_busy(spi_p->tx_dma);
 
     // Print debug information if the DMA channels are still busy
     if (timed_out) {
@@ -134,9 +208,8 @@ bool spi_transfer_wait_complete(spi_t *spi_p, uint32_t timeout_ms) {
     } else {
         // If the DMA channels are not busy, wait for the SPI peripheral to become idle
         start = millis();
-        do {
+        while (spi_is_busy(spi_p->hw_inst) && millis() - start < timeout_ms)
             tight_loop_contents();
-        } while (spi_is_busy(spi_p->hw_inst) && millis() - start < timeout_ms);
 
         // Check if the SPI peripheral is still busy
         timed_out = spi_is_busy(spi_p->hw_inst);
@@ -148,15 +221,29 @@ bool spi_transfer_wait_complete(spi_t *spi_p, uint32_t timeout_ms) {
     }
 
     // Check the status of the SPI peripheral
-    bool spi_ok = chk_spi(spi_p->hw_inst);
+    bool spi_ok = chk_spi(spi_p);
 
+    if (timed_out || !spi_ok) {
+        chk_dmas(spi_p);
+        DBG_PRINTF("DMA_INTR: 0b%s\n", uint_binary_str(dma_hw->intr));
+        DBG_PRINTF("TX DMA CTRL_TRIG: 0b%s\n",
+                   uint_binary_str(dma_hw->ch[spi_p->tx_dma].ctrl_trig));
+        DBG_PRINTF("RX DMA CTRL_TRIG: 0b%s\n",
+                   uint_binary_str(dma_hw->ch[spi_p->rx_dma].ctrl_trig));
+        DBG_PRINTF("SPI SSPCR0: 0b%s\n", uint_binary_str(spi_get_hw(spi_p->hw_inst)->cr0));
+        DBG_PRINTF("SPI SSPCR1: 0b%s\n", uint_binary_str(spi_get_hw(spi_p->hw_inst)->cr1));
+        DBG_PRINTF("SPI_SSPSR: 0b%s\n", uint_binary_str(spi_get_const_hw(spi_p->hw_inst)->sr));
+        DBG_PRINTF("SPI_SSPDMACR: 0b%s\n",
+                   uint_binary_str(spi_get_const_hw(spi_p->hw_inst)->dmacr));
+        dma_channel_abort(spi_p->rx_dma);
+        dma_channel_abort(spi_p->tx_dma);
+    }
     // Return true if the transfer is complete and the SPI peripheral is in a good state
     return !(timed_out || !spi_ok);
 }
 
 /**
- * @brief Perform a simultaneous read and write operation on the SPI bus.
- *
+ * SPI Transfer: Read & Write (simultaneously) on SPI bus
  * @param spi_p Pointer to the SPI object.
  * @param tx Pointer to the transmit buffer. If NULL, SPI_FILL_CHAR is sent as each data
  * element.
@@ -165,21 +252,12 @@ bool spi_transfer_wait_complete(spi_t *spi_p, uint32_t timeout_ms) {
  * @return true if the transfer is completed successfully within the timeout.
  * @return false if the transfer times out or encounters an error.
  */
-bool spi_transfer(spi_t *spi_p, const uint8_t *tx, uint8_t *rx, size_t length) {
-    // Start the SPI transfer
+bool __not_in_flash_func(spi_transfer)(spi_t *spi_p, const uint8_t *tx, uint8_t *rx,
+                                       size_t length) {
     spi_transfer_start(spi_p, tx, rx, length);
-
-    // Wait for the transfer to complete within the specified timeout
-    return spi_transfer_wait_complete(spi_p, 2000);
-}
-
-void spi_lock(spi_t *spi_p) {
-    myASSERT(mutex_is_initialized(&spi_p->mutex));
-    mutex_enter_blocking(&spi_p->mutex);
-}
-void spi_unlock(spi_t *spi_p) {
-    myASSERT(mutex_is_initialized(&spi_p->mutex));
-    mutex_exit(&spi_p->mutex);
+    // Related to timeouts in spi_lock and sd_lock
+    uint32_t timeout = calculate_transfer_time_ms(spi_p, length);
+    return spi_transfer_wait_complete(spi_p, timeout);
 }
 
 /**
@@ -198,13 +276,30 @@ bool my_spi_init(spi_t *spi_p) {
 
         // Defaults:
         if (!spi_p->hw_inst) spi_p->hw_inst = spi0;
-        if (!spi_p->baud_rate) spi_p->baud_rate = 12500000;  // default
+        if (!spi_p->baud_rate) spi_p->baud_rate = clock_get_hz(clk_sys) / 12;
 
         /* Configure component */
         // Enable SPI at 100 kHz and connect to GPIOs
         spi_init(spi_p->hw_inst, 100 * 1000);
-        spi_set_format(spi_p->hw_inst, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
 
+        myASSERT(spi_p->spi_mode < 4);
+        switch (spi_p->spi_mode) {
+            case 0:
+                spi_set_format(spi_p->hw_inst, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+                break;
+            case 1:
+                spi_set_format(spi_p->hw_inst, 8, SPI_CPOL_0, SPI_CPHA_1, SPI_MSB_FIRST);
+                break;
+            case 2:
+                spi_set_format(spi_p->hw_inst, 8, SPI_CPOL_1, SPI_CPHA_0, SPI_MSB_FIRST);
+                break;
+            case 3:
+                spi_set_format(spi_p->hw_inst, 8, SPI_CPOL_1, SPI_CPHA_1, SPI_MSB_FIRST);
+                break;
+            default:
+                spi_set_format(spi_p->hw_inst, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+                break;
+        }
         gpio_set_function(spi_p->miso_gpio, GPIO_FUNC_SPI);
         gpio_set_function(spi_p->mosi_gpio, GPIO_FUNC_SPI);
         gpio_set_function(spi_p->sck_gpio, GPIO_FUNC_SPI);
@@ -232,7 +327,7 @@ bool my_spi_init(spi_t *spi_p) {
         // SD cards' DO MUST be pulled up. However, it might be done externally.
         if (!spi_p->no_miso_gpio_pull_up) gpio_pull_up(spi_p->miso_gpio);
 
-        gpio_set_input_hysteresis_enabled(spi_p->miso_gpio, false);
+        // gpio_set_input_hysteresis_enabled(spi_p->miso_gpio, false);
 
         // Check if the user has provided DMA channels
         if (spi_p->use_static_dma_channels) {
@@ -253,16 +348,14 @@ bool my_spi_init(spi_t *spi_p) {
         // transmit FIFO paced by the SPI TX FIFO DREQ The default is for the
         // read address to increment every element (in this case 1 byte -
         // DMA_SIZE_8) and for the write address to remain unchanged.
-        channel_config_set_dreq(&spi_p->tx_dma_cfg,
-                                spi_get_index(spi_p->hw_inst) ? DREQ_SPI1_TX : DREQ_SPI0_TX);
+        channel_config_set_dreq(&spi_p->tx_dma_cfg, spi_get_dreq(spi_p->hw_inst, true));
         channel_config_set_write_increment(&spi_p->tx_dma_cfg, false);
 
         // We set the inbound DMA to transfer from the SPI receive FIFO to a
-        // memory buffer paced by the SPI RX FIFO DREQ We coinfigure the read
+        // memory buffer paced by the SPI RX FIFO DREQ We configure the read
         // address to remain unchanged for each element, but the write address
         // to increment (so data is written throughout the buffer)
-        channel_config_set_dreq(&spi_p->rx_dma_cfg,
-                                spi_get_index(spi_p->hw_inst) ? DREQ_SPI1_RX : DREQ_SPI0_RX);
+        channel_config_set_dreq(&spi_p->rx_dma_cfg, spi_get_dreq(spi_p->hw_inst, false));
         channel_config_set_read_increment(&spi_p->rx_dma_cfg, false);
 
         LED_INIT();

--- a/src/sd_driver/SPI/sd_card_spi.c
+++ b/src/sd_driver/SPI/sd_card_spi.c
@@ -179,6 +179,7 @@
 #include "sd_card.h"
 #include "sd_card_constants.h"
 #include "sd_spi.h"
+#include "sd_timeouts.h"
 #include "util.h"
 //
 #include "sd_card_spi.h"
@@ -204,45 +205,69 @@ static bool crc_on = false;
 #endif
 
 #define TRACE_PRINTF(fmt, args...)
-// #define TRACE_PRINTF printf  // task_printf
+//#define TRACE_PRINTF DBG_PRINTF
 
-/* Control Tokens   */
-#define SPI_DATA_RESPONSE_MASK (0x1F)
-#define SPI_DATA_ACCEPTED (0x05)
-#define SPI_DATA_CRC_ERROR (0x0B)
-#define SPI_DATA_WRITE_ERROR (0x0D)
-#define SPI_START_BLOCK (0xFE) /*!< For Single Block Read/Write and Multiple Block Read */
-#define SPI_START_BLK_MUL_WRITE (0xFC) /*!< Start Multi-block write */
-#define SPI_STOP_TRAN (0xFD)           /*!< Stop Multi-block write */
+/**
+ * @brief Control Tokens
+ */
+typedef enum {
+    SPI_DATA_RESPONSE_MASK = 0x1F,
+    SPI_DATA_ACCEPTED = 0x05,
+    SPI_DATA_CRC_ERROR = 0x0B,
+    SPI_DATA_WRITE_ERROR = 0x0D,
+    SPI_START_BLOCK = 0xFE,
+    SPI_START_BLK_MUL_WRITE = 0xFC,
+    SPI_STOP_TRAN = 0xFD,
+} spi_control_t;
 
-#define SPI_DATA_READ_ERROR_MASK (0xF)  /*!< Data Error Token: 4 LSB bits */
-#define SPI_READ_ERROR (0x1 << 0)       /*!< Error */
-#define SPI_READ_ERROR_CC (0x1 << 1)    /*!< CC Error*/
-#define SPI_READ_ERROR_ECC_C (0x1 << 2) /*!< Card ECC failed */
-#define SPI_READ_ERROR_OFR (0x1 << 3)   /*!< Out of Range */
+/**
+ * @brief Data Error Token Mask
+ */
+typedef enum {
+    SPI_DATA_READ_ERROR_MASK = 0xF,
+} spi_data_read_error_mask_t;
 
-/* R1 Response Format */
-#define R1_NO_RESPONSE (0xFF)
-#define R1_RESPONSE_RECV (0x80)
-#define R1_IDLE_STATE (1 << 0)
-#define R1_ERASE_RESET (1 << 1)
-#define R1_ILLEGAL_COMMAND (1 << 2)
-#define R1_COM_CRC_ERROR (1 << 3)
-#define R1_ERASE_SEQUENCE_ERROR (1 << 4)
-#define R1_ADDRESS_ERROR (1 << 5)
-#define R1_PARAMETER_ERROR (1 << 6)
+/**
+ * @brief Data Error Token Flags
+ */
+typedef enum {
+    SPI_READ_ERROR = 0x1 << 0,
+    SPI_READ_ERROR_CC = 0x1 << 1,
+    SPI_READ_ERROR_ECC_C = 0x1 << 2,
+    SPI_READ_ERROR_OFR = 0x1 << 3,
+} spi_data_read_error_t;
+
+/**
+ * @brief R1 Response Format
+ */
+typedef enum {
+    R1_NO_RESPONSE = 0xFF,
+    R1_RESPONSE_RECV = 0x80,
+    R1_IDLE_STATE = 1 << 0,
+    R1_ERASE_RESET = 1 << 1,
+    R1_ILLEGAL_COMMAND = 1 << 2,
+    R1_COM_CRC_ERROR = 1 << 3,
+    R1_ERASE_SEQUENCE_ERROR = 1 << 4,
+    R1_ADDRESS_ERROR = 1 << 5,
+    R1_PARAMETER_ERROR = 1 << 6,
+} spi_r1_response_t;
 
 /* SIZE in Bytes */
 #define PACKET_SIZE 6         /*!< SD Packet size CMD+ARG+CRC */
-#define R1_RESPONSE_SIZE 1    /*!< Size of R1 response */
-#define R2_RESPONSE_SIZE 2    /*!< Size of R2 response */
-#define R3_R7_RESPONSE_SIZE 5 /*!< Size of R3/R7 response */
+/**
+ * @brief OCR Register Flags
+ */
+typedef enum {
+    OCR_HCS_CCS = 0x1 << 30,
+    OCR_LOW_VOLTAGE = 0x01 << 24,
+    OCR_3_3V = 0x1 << 20,
+} spi_ocr_register_t;
 
-/* R3 Response : OCR Register */
-#define OCR_HCS_CCS (0x1 << 30)
-#define OCR_LOW_VOLTAGE (0x01 << 24)
-#define OCR_3_3V (0x1 << 20)
-
+/**
+ * @brief Control Command
+ *
+ * @param x Command
+ */
 #define SPI_CMD(x) (0x40 | (x & 0x3f))
 
 #pragma GCC diagnostic push
@@ -268,51 +293,54 @@ static bool crc_on = false;
  * should be discarded.
  */
 static uint8_t sd_cmd_spi(sd_card_t *sd_card_p, cmdSupported cmd, uint32_t arg) {
-    uint8_t response;
-    uint8_t cmdPacket[PACKET_SIZE];
-
-    // Prepare the command packet
-    cmdPacket[0] = SPI_CMD(cmd);
-    cmdPacket[1] = (arg >> 24);
-    cmdPacket[2] = (arg >> 16);
-    cmdPacket[3] = (arg >> 8);
-    cmdPacket[4] = (arg >> 0);
+    uint8_t cmd_packet[PACKET_SIZE] = {
+        SPI_CMD(cmd),
+        (arg >> 24),
+        (arg >> 16),
+        (arg >> 8),
+        (arg >> 0),
+    };
 
     if (crc_on) {
-        cmdPacket[5] = (crc7(cmdPacket, 5) << 1) | 0x01;
+        cmd_packet[5] = (crc7(cmd_packet, 5) << 1) | 0x01;
     } else {
         // CMD0 is executed in SD mode, hence should have correct CRC
         // CMD8 CRC verification is always enabled
         switch (cmd) {
             case CMD0_GO_IDLE_STATE:
-                cmdPacket[5] = 0x95;
+                cmd_packet[5] = 0x95;
                 break;
             case CMD8_SEND_IF_COND:
-                cmdPacket[5] = 0x87;
+                cmd_packet[5] = 0x87;
                 break;
             default:
-                cmdPacket[5] = 0xFF;  // Make sure bit 0-End bit is high
+                // Make sure bit 0-End bit is high
+                cmd_packet[5] = 0xFF;
                 break;
         }
     }
     // send a command
-    for (int i = 0; i < PACKET_SIZE; i++) {
-        sd_spi_write(sd_card_p, cmdPacket[i]);
+    for (size_t i = 0; i < PACKET_SIZE; i++) {
+        sd_spi_write(sd_card_p, cmd_packet[i]);
     }
+
     // The received byte immediately following CMD12 is a stuff byte,
     // it should be discarded before receive the response of the CMD12.
     if (CMD12_STOP_TRANSMISSION == cmd) {
         sd_spi_write(sd_card_p, SPI_FILL_CHAR);
     }
+
     // Loop for response: Response is sent back within command response time
     // (NCR), 0 to 8 bytes for SDC
-    for (int i = 0; i < 0x10; i++) {
-        response = sd_spi_write(sd_card_p, SPI_FILL_CHAR);
+    uint8_t response;
+    for (size_t i = 0; i < 0x10; i++) {
+        response = sd_spi_read(sd_card_p);
         // Got the response
         if (!(response & R1_RESPONSE_RECV)) {
             break;
         }
     }
+
     return response;
 }
 #pragma GCC diagnostic pop
@@ -334,13 +362,15 @@ static bool sd_wait_ready(sd_card_t *sd_card_p, uint32_t timeout) {
     // DO line
     uint32_t start = millis();
     do {
-        resp = sd_spi_write(sd_card_p, 0xFF);
-    } while (resp == 0x00 && millis() - start < timeout);
-
-    if (resp == 0x00) DBG_PRINTF("%s failed\n", __FUNCTION__);
+        resp = sd_spi_write_read(sd_card_p, 0xFF);
+    } while (resp != 0xFF && millis() - start < timeout);
+    /* Checking for 0xFF provides a little extra margin to 
+    make sure that DO has gone high and stayed there.
+    (the alternative is to accept the first non-zero byte) */
+    if (resp != 0xFF) DBG_PRINTF("%s failed\n", __FUNCTION__);
 
     // Return success/failure
-    return (resp > 0x00);
+    return (0xFF == resp);
 }
 
 /* Locks the SD card and acquires its SPI
@@ -355,8 +385,8 @@ static void sd_acquire(sd_card_t *sd_card_p) {
     sd_spi_acquire(sd_card_p);
 }
 static void sd_release(sd_card_t *sd_card_p) {
-    sd_unlock(sd_card_p);
     sd_spi_release(sd_card_p);
+    sd_unlock(sd_card_p);
 }
 
 #if TRACE
@@ -497,9 +527,6 @@ static int chk_CMD13_response(uint32_t response) {
     return status;
 }
 
-#define SD_COMMAND_RETRIES 3    /*!< Times SPI cmd is retried when there is no response */
-#define SD_COMMAND_TIMEOUT 2000 /*!< Timeout in ms for response */
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wswitch-enum"
 
@@ -513,7 +540,7 @@ static int chk_CMD13_response(uint32_t response) {
  * @return error code
  *
  * This function sends a command to the SD card and waits for the response.
- * It will retry the command up to SD_COMMAND_RETRIES times if there is no response.
+ * It will retry the command up to sd_timeouts.sd_command_retries times if there is no response.
  * The response is stored in the @p resp variable if it is not NULL.
  * The function will return SD_BLOCK_DEVICE_ERROR_NONE if the command was successful,
  * SD_BLOCK_DEVICE_ERROR_NO_RESPONSE if there was no response,
@@ -522,30 +549,28 @@ static int chk_CMD13_response(uint32_t response) {
  * SD_BLOCK_DEVICE_ERROR_PARAMETER if there was a parameter error,
  * SD_BLOCK_DEVICE_ERROR_ERASE if there was an erase error.
  */
-
 static block_dev_err_t sd_cmd(sd_card_t *sd_card_p, const cmdSupported cmd, uint32_t arg,
                               bool isAcmd, uint32_t *resp) {
-//    TRACE_PRINTF("%s(%s(0x%08lx)): ", __FUNCTION__, cmd2str(cmd), arg);
+    //    TRACE_PRINTF("%s(%s(0x%08lx)): ", __FUNCTION__, cmd2str(cmd), arg);
     myASSERT(sd_is_locked(sd_card_p));
     myASSERT(0 == gpio_get(sd_card_p->spi_if_p->ss_gpio));
 
     int32_t status = SD_BLOCK_DEVICE_ERROR_NONE;
-    uint32_t response;
+    uint32_t response = 0;
 
     // No need to wait for card to be ready when sending the stop command
     if (CMD12_STOP_TRANSMISSION != cmd && CMD0_GO_IDLE_STATE != cmd) {
-        if (false == sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT)) {
+        if (false == sd_wait_ready(sd_card_p, sd_timeouts.sd_command)) {
             DBG_PRINTF("Card not ready yet\n");
             return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
         }
     }
-    // Re-try command
-    for (int i = 0; i < SD_COMMAND_RETRIES; i++) {
+    for (unsigned i = 0; i < sd_timeouts.sd_command_retries; i++) {
         // Send CMD55 for APP command first
         if (isAcmd) {
             response = sd_cmd_spi(sd_card_p, CMD55_APP_CMD, 0x0);
             // Wait for card to be ready after CMD55
-            if (false == sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT)) {
+            if (false == sd_wait_ready(sd_card_p, sd_timeouts.sd_command)) {
                 DBG_PRINTF("Card not ready yet\n");
             }
         }
@@ -553,6 +578,7 @@ static block_dev_err_t sd_cmd(sd_card_t *sd_card_p, const cmdSupported cmd, uint
         response = sd_cmd_spi(sd_card_p, cmd, arg);
         if (R1_NO_RESPONSE == response) {
             DBG_PRINTF("No response CMD:%d\n", cmd);
+            // Re-try command
             continue;
         }
         break;
@@ -597,19 +623,19 @@ static block_dev_err_t sd_cmd(sd_card_t *sd_card_p, const cmdSupported cmd, uint
             sd_card_p->state.card_type = SDCARD_V2;  // fallthrough
             // Note: No break here, need to read rest of the response
         case CMD58_READ_OCR:  // Response R3
-            response = (sd_spi_write(sd_card_p, SPI_FILL_CHAR) << 24);
-            response |= (sd_spi_write(sd_card_p, SPI_FILL_CHAR) << 16);
-            response |= (sd_spi_write(sd_card_p, SPI_FILL_CHAR) << 8);
-            response |= sd_spi_write(sd_card_p, SPI_FILL_CHAR);
+            response = (sd_spi_read(sd_card_p) << 24);
+            response |= (sd_spi_read(sd_card_p) << 16);
+            response |= (sd_spi_read(sd_card_p) << 8);
+            response |= sd_spi_read(sd_card_p);
             DBG_PRINTF("R3/R7: 0x%" PRIx32 "\n", response);
             break;
         case CMD12_STOP_TRANSMISSION:  // Response R1b
         case CMD38_ERASE:
-            sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT);
+            sd_wait_ready(sd_card_p, sd_timeouts.sd_command);
             break;
         case CMD13_SEND_STATUS:  // Response R2
             response <<= 8;
-            response |= sd_spi_write(sd_card_p, SPI_FILL_CHAR);
+            response |= sd_spi_read(sd_card_p);
             if (response) status = chk_CMD13_response(response);
         default:;
     }
@@ -659,7 +685,7 @@ static block_dev_err_t sd_cmd8(sd_card_t *sd_card_p) {
     return status;
 }
 
-static block_dev_err_t sd_read_bytes(sd_card_t *sd_card_p, uint8_t *buffer, uint32_t length);
+static block_dev_err_t read_bytes(sd_card_t *sd_card_p, uint8_t *buffer, uint32_t length);
 
 /**
  * @brief Get the number of sectors on an SD card.
@@ -677,7 +703,7 @@ static uint32_t in_sd_spi_sectors(sd_card_t *sd_card_p) {
         DBG_PRINTF("Didn't get a response from the disk\n");
         return 0;
     }
-    if (sd_read_bytes(sd_card_p, sd_card_p->state.CSD, 16) != 0) {
+    if (read_bytes(sd_card_p, sd_card_p->state.CSD, 16) != 0) {
         DBG_PRINTF("Couldn't read CSD response from disk\n");
         return 0;
     }
@@ -714,14 +740,14 @@ uint32_t sd_spi_sectors(sd_card_t *sd_card_p) {
  *          the function returns false.
  */
 static bool sd_wait_token(sd_card_t *sd_card_p, uint8_t token) {
-    TRACE_PRINTF("%s(0x%02x)\n", __FUNCTION__, token);
+    //TRACE_PRINTF("%s(0x%02x)\n", __FUNCTION__, token);
 
     uint32_t start = millis();
     do {
-        if (token == sd_spi_write(sd_card_p, SPI_FILL_CHAR)) {
+        if (token == sd_spi_read(sd_card_p)) {
             return true;
         }
-    } while (millis() - start < SD_COMMAND_TIMEOUT);
+    } while (millis() - start < sd_timeouts.sd_command);
 
     DBG_PRINTF("sd_wait_token: timeout\n");
     return false;
@@ -744,20 +770,20 @@ static bool chk_crc16(uint8_t *buffer, size_t length, uint16_t crc) {
 
 static block_dev_err_t stop_wr_tran(sd_card_t *sd_card_p);
 
-static block_dev_err_t sd_read_bytes(sd_card_t *sd_card_p, uint8_t *buffer, uint32_t length) {
+static block_dev_err_t read_bytes(sd_card_t *sd_card_p, uint8_t *buffer, uint32_t length) {
     uint16_t crc;
 
     // read until start byte (0xFE)
     if (false == sd_wait_token(sd_card_p, SPI_START_BLOCK)) {
-        DBG_PRINTF("%s:%d Read timeout\n", __FILE__, __LINE__);
+        DBG_PRINTF("%s:%d Read timeout\n", __func__, __LINE__);
         return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
     }
     bool ok = sd_spi_transfer(sd_card_p, NULL, buffer, length);
     if (!ok) return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
 
     // Read the CRC16 checksum for the data block
-    crc = (sd_spi_write(sd_card_p, SPI_FILL_CHAR) << 8);
-    crc |= sd_spi_write(sd_card_p, SPI_FILL_CHAR);
+    crc = (sd_spi_read(sd_card_p) << 8);
+    crc |= sd_spi_read(sd_card_p);
 
     if (!chk_crc16(buffer, length, crc)) {
         DBG_PRINTF("%s: Invalid CRC received: 0x%" PRIx16 "\n", __func__, crc);
@@ -803,7 +829,6 @@ static block_dev_err_t in_sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
     if (sd_card_p->spi_if_p->state.ongoing_mlt_blk_wrt) {
         status = stop_wr_tran(sd_card_p);
         if (SD_BLOCK_DEVICE_ERROR_NONE != status) return status;
-        sd_spi_deselect_pulse(sd_card_p);
     }
 
     // Send command to receive data
@@ -826,12 +851,13 @@ static block_dev_err_t in_sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
     while (blk_cnt) {
         // read until start byte (0xFE)
         if (!sd_wait_token(sd_card_p, SPI_START_BLOCK)) {
-            DBG_PRINTF("%s:%d Read timeout\n", __FILE__, __LINE__);
+            DBG_PRINTF("%s:%d Read timeout\n", __func__, __LINE__);
             return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
         }
         // read data
         sd_spi_transfer_start(sd_card_p, NULL, buffer, sd_block_size);
 
+        // Check the CRC16 checksum for the previous data block
         if (prev_buffer_addr) {
             // Check previous block's CRC:
             if (!chk_crc16(prev_buffer_addr, sd_block_size, prev_block_crc)) {
@@ -840,12 +866,14 @@ static block_dev_err_t in_sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
                 return SD_BLOCK_DEVICE_ERROR_CRC;
             }
         }
-        bool ok = sd_spi_transfer_wait_complete(sd_card_p, 1000);
+        
+        uint32_t timeout = calculate_transfer_time_ms(sd_card_p->spi_if_p->spi, sd_block_size);
+        bool ok = sd_spi_transfer_wait_complete(sd_card_p, timeout);
         if (!ok) return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
 
         // Read the CRC16 checksum for the data block
-        prev_block_crc = (sd_spi_write(sd_card_p, SPI_FILL_CHAR) << 8);
-        prev_block_crc |= sd_spi_write(sd_card_p, SPI_FILL_CHAR);
+        prev_block_crc = sd_spi_read(sd_card_p) << 8;
+        prev_block_crc |= sd_spi_read(sd_card_p);
         prev_buffer_addr = buffer;
         buffer += sd_block_size;
         --blk_cnt;
@@ -865,10 +893,18 @@ static block_dev_err_t in_sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
 }
 static block_dev_err_t sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
                                       uint32_t data_address, uint32_t num_rd_blks) {
-    TRACE_PRINTF("sd_read_blocks(0x%p, 0x%lx, 0x%lx)\n", buffer, data_address,
-                 num_rd_blks);
+    TRACE_PRINTF("sd_read_blocks(0x%p, 0x%lx, 0x%lx)\n", buffer, data_address, num_rd_blks);
     sd_acquire(sd_card_p);
-    int status = in_sd_read_blocks(sd_card_p, buffer, data_address, num_rd_blks);
+    unsigned retries = sd_timeouts.sd_command_retries;
+    block_dev_err_t status;
+    do {
+        status = in_sd_read_blocks(sd_card_p, buffer, data_address, num_rd_blks);
+        if (status != SD_BLOCK_DEVICE_ERROR_NONE) {
+            if (SD_BLOCK_DEVICE_ERROR_NONE !=
+                sd_cmd(sd_card_p, CMD12_STOP_TRANSMISSION, 0x0, false, 0))
+                return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
+        }
+    } while (--retries && status != SD_BLOCK_DEVICE_ERROR_NONE);
     sd_release(sd_card_p);
     return status;
 }
@@ -888,7 +924,7 @@ static block_dev_err_t sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
  *         SD_BLOCK_DEVICE_ERROR_CRC if there was a CRC error reading the response,
  *         SD_BLOCK_DEVICE_ERROR_PARAMETER if an invalid parameter was passed.
  */
-static block_dev_err_t sd_SEND_NUM_WR_BLOCKS(sd_card_t *sd_card_p, uint32_t *num_p) {
+static block_dev_err_t get_num_wr_blocks(sd_card_t *sd_card_p, uint32_t *num_p) {
     // Send the ACMD22 command to get the number of written blocks
     block_dev_err_t err = sd_cmd(sd_card_p, ACMD22_SEND_NUM_WR_BLOCKS, 0, true, NULL);
     
@@ -899,7 +935,7 @@ static block_dev_err_t sd_SEND_NUM_WR_BLOCKS(sd_card_t *sd_card_p, uint32_t *num
     }
     
     // Read the response from the SD card and store it in the num_p variable
-    err = sd_read_bytes(sd_card_p, (uint8_t *)num_p, sizeof(uint32_t));
+    err = read_bytes(sd_card_p, (uint8_t *)num_p, sizeof(uint32_t));
     *num_p = __builtin_bswap32(*num_p);
     
     // If there was an error reading the response, return the error code
@@ -929,13 +965,13 @@ static block_dev_err_t sd_SEND_NUM_WR_BLOCKS(sd_card_t *sd_card_p, uint32_t *num
  * transfer is complete, the function writes the CRC16 checksum to the SD card. Finally, the function
  * checks the response token and returns an error code if the data was not accepted.
  */
-static block_dev_err_t sd_send_block(sd_card_t *sd_card_p, const uint8_t *buffer, uint8_t token,
+static block_dev_err_t send_block(sd_card_t *sd_card_p, const uint8_t *buffer, uint8_t token,
                                      uint32_t length)
 {
     uint8_t response;
 
     /* Indicate start of block - Start Block Token */
-    response = sd_spi_write(sd_card_p, token);
+    response = sd_spi_write_read(sd_card_p, token);
     if (!response) {
         DBG_PRINTF("Start Block Token not accepted. Response: 0x%x\n", response);
         return SD_BLOCK_DEVICE_ERROR_WRITE;
@@ -957,8 +993,8 @@ static block_dev_err_t sd_send_block(sd_card_t *sd_card_p, const uint8_t *buffer
         // Compute CRC
         crc = crc16((void *)buffer, length);
     }
-
-    bool ok = sd_spi_transfer_wait_complete(sd_card_p, 1000);
+    uint32_t timeout = calculate_transfer_time_ms(sd_card_p->spi_if_p->spi, length);
+    bool ok = sd_spi_transfer_wait_complete(sd_card_p, timeout);
     if (!ok) return SD_BLOCK_DEVICE_ERROR_WRITE;
 
     // Write the checksum CRC16
@@ -968,7 +1004,7 @@ static block_dev_err_t sd_send_block(sd_card_t *sd_card_p, const uint8_t *buffer
     block_dev_err_t rc = SD_BLOCK_DEVICE_ERROR_NONE;
 
     // Check the response token
-    response = sd_spi_write(sd_card_p, SPI_FILL_CHAR);
+    response = sd_spi_read(sd_card_p);
 
     // Only CRC and general write error are communicated via response token
     if ((response & SPI_DATA_RESPONSE_MASK) != SPI_DATA_ACCEPTED) {
@@ -995,8 +1031,8 @@ static block_dev_err_t sd_send_block(sd_card_t *sd_card_p, const uint8_t *buffer
         rc = SD_BLOCK_DEVICE_ERROR_WRITE;
     }
     // Wait while card is busy programming
-    if (false == sd_wait_ready(sd_card_p, SD_COMMAND_TIMEOUT)) {
-        DBG_PRINTF("%s:%d: Card not ready yet\n", __FILE__, __LINE__);
+    if (false == sd_wait_ready(sd_card_p, sd_timeouts.sd_command)) {
+        DBG_PRINTF("%s:%d: Card not ready yet\n", __func__, __LINE__);
         rc = SD_BLOCK_DEVICE_ERROR_WRITE;
     }
     return rc;
@@ -1005,7 +1041,7 @@ static block_dev_err_t sd_send_block(sd_card_t *sd_card_p, const uint8_t *buffer
  * @brief Send all blocks of data, one block at a time.
  * 
  * The function performs the following steps:
- *  - Sends each block of data using the sd_send_block() function
+ *  - Sends each block of data using the send_block() function
  *  - Checks the status of each send operation and stop if there is an error
  *  - Updates the buffer pointer and data address after each send operation
  *  - Sets the ongoing_mlt_blk_wrt flag to true if all blocks are sent successfully
@@ -1022,13 +1058,13 @@ static block_dev_err_t sd_send_block(sd_card_t *sd_card_p, const uint8_t *buffer
  * @return SD_BLOCK_DEVICE_ERROR_NONE if all blocks are sent successfully,
  *         otherwise an error code.
  */
-static block_dev_err_t sd_send_all_blocks(sd_card_t *sd_card_p, const uint8_t *buffer_p[],
+static block_dev_err_t send_all_blocks(sd_card_t *sd_card_p, const uint8_t *buffer_p[],
         uint32_t * const data_address_p,
         uint32_t * const num_wrt_blks_p)
 {
     block_dev_err_t status;
     do {
-        status = sd_send_block(sd_card_p, *buffer_p, SPI_START_BLK_MUL_WRITE, sd_block_size);
+        status = send_block(sd_card_p, *buffer_p, SPI_START_BLK_MUL_WRITE, sd_block_size);
         if (SD_BLOCK_DEVICE_ERROR_NONE != status) break;
         *buffer_p += sd_block_size;
         ++*data_address_p;
@@ -1041,9 +1077,8 @@ static block_dev_err_t sd_send_all_blocks(sd_card_t *sd_card_p, const uint8_t *b
         // sd_card_p->spi_if_p->state.n_wrt_blks_reqd cleared in stop_wr_tran
         uint32_t n_wrt_blks_reqd = sd_card_p->spi_if_p->state.n_wrt_blks_reqd;
         stop_wr_tran(sd_card_p); // Ignore return value
-        sd_spi_deselect_pulse(sd_card_p);
         uint32_t nw;
-        block_dev_err_t err = sd_SEND_NUM_WR_BLOCKS(sd_card_p, &nw);
+        block_dev_err_t err = get_num_wr_blocks(sd_card_p, &nw);
         if (SD_BLOCK_DEVICE_ERROR_NONE == err) {
             DBG_PRINTF("blocks_requested: %lu, NUM_WR_BLOCKS: %lu\n",
                     n_wrt_blks_reqd, nw);
@@ -1068,7 +1103,8 @@ static block_dev_err_t sd_send_all_blocks(sd_card_t *sd_card_p, const uint8_t *b
  *                       write.
  * @return block_dev_err_t Error code indicating the status of the write operation.
  */
-static block_dev_err_t in_sd_write_blocks(sd_card_t *sd_card_p, const uint8_t *buffer_p[],
+static block_dev_err_t in_sd_write_blocks(sd_card_t *sd_card_p, 
+                                          const uint8_t *buffer_p[],
                                           uint32_t * const data_address_p,
                                           uint32_t * const num_wrt_blks_p)
 {
@@ -1080,14 +1116,13 @@ static block_dev_err_t in_sd_write_blocks(sd_card_t *sd_card_p, const uint8_t *b
         // Update the number of blocks requested for write
         sd_card_p->spi_if_p->state.n_wrt_blks_reqd += *num_wrt_blks_p;
         // Send all blocks of data
-        return sd_send_all_blocks(sd_card_p, buffer_p, data_address_p, num_wrt_blks_p);
+        return send_all_blocks(sd_card_p, buffer_p, data_address_p, num_wrt_blks_p);
     }
 
     // Stop any ongoing write transmission
     if (sd_card_p->spi_if_p->state.ongoing_mlt_blk_wrt) {
         status = stop_wr_tran(sd_card_p);
         if (SD_BLOCK_DEVICE_ERROR_NONE != status) return status;
-        sd_spi_deselect_pulse(sd_card_p);
     }
 
     // Send command to perform write operation
@@ -1097,7 +1132,7 @@ static block_dev_err_t in_sd_write_blocks(sd_card_t *sd_card_p, const uint8_t *b
     // Update the number of blocks requested for write
     sd_card_p->spi_if_p->state.n_wrt_blks_reqd = *num_wrt_blks_p;
     // Send all blocks of data
-    return sd_send_all_blocks(sd_card_p, buffer_p, data_address_p, num_wrt_blks_p);
+    return send_all_blocks(sd_card_p, buffer_p, data_address_p, num_wrt_blks_p);
     /* Optimization:
     To optimize large contiguous writes,
     postpone stopping transmission until it is
@@ -1126,13 +1161,15 @@ static block_dev_err_t stop_wr_tran(sd_card_t *sd_card_p) {
     the host via the data-response token is CRC.
     */
 
-    // Some SD cards want to be deselected between every command:
-    sd_spi_deselect_pulse(sd_card_p);
+    if (false == sd_wait_ready(sd_card_p, sd_timeouts.sd_command)) {
+        DBG_PRINTF("Card not ready yet\n");
+    }
 
     uint32_t stat = 0;
     sd_card_p->spi_if_p->state.n_wrt_blks_reqd = 0;
     return sd_cmd(sd_card_p, CMD13_SEND_STATUS, 0, false, &stat);
 }
+
 /**
  * @brief Writes a single block to the SD card
  *
@@ -1144,7 +1181,7 @@ static block_dev_err_t stop_wr_tran(sd_card_t *sd_card_p) {
  * - SD_BLOCK_DEVICE_ERROR_NONE on success
  * - error code on failure
  */
-static block_dev_err_t in_sd_write_block(sd_card_t *sd_card_p, const uint8_t *buffer,
+static block_dev_err_t write_block(sd_card_t *sd_card_p, const uint8_t *buffer,
                                           uint32_t const address)
 {
     // Stop any ongoing multiple block write transmission
@@ -1152,7 +1189,6 @@ static block_dev_err_t in_sd_write_block(sd_card_t *sd_card_p, const uint8_t *bu
     if (sd_card_p->spi_if_p->state.ongoing_mlt_blk_wrt) {
         status = stop_wr_tran(sd_card_p);
         if (SD_BLOCK_DEVICE_ERROR_NONE != status) return status;
-        sd_spi_deselect_pulse(sd_card_p);
     }
 
     // Send command to perform the write operation
@@ -1160,7 +1196,7 @@ static block_dev_err_t in_sd_write_block(sd_card_t *sd_card_p, const uint8_t *bu
     if (SD_BLOCK_DEVICE_ERROR_NONE != status) return status;
 
     // Write data
-    sd_send_block(sd_card_p, buffer, SPI_START_BLOCK, sd_block_size);
+    send_block(sd_card_p, buffer, SPI_START_BLOCK, sd_block_size);
 
     /*
     Once the programming operation is completed, the
@@ -1172,9 +1208,6 @@ static block_dev_err_t in_sd_write_block(sd_card_t *sd_card_p, const uint8_t *bu
     performed on the data block and communicated to
     the host via the data-response token is CRC.
     */
-
-    // Some SD cards want to be deselected between every command:
-    sd_spi_deselect_pulse(sd_card_p);
 
     // Send command to get the status of the card
     uint32_t stat = 0;
@@ -1203,6 +1236,7 @@ static block_dev_err_t in_sd_write_block(sd_card_t *sd_card_p, const uint8_t *bu
 static block_dev_err_t sd_write_blocks(sd_card_t *sd_card_p, uint8_t const buffer[],
                                        uint32_t data_address, uint32_t num_wrt_blks) 
 {
+        TRACE_PRINTF("%s(0x%p, 0x%lx, 0x%lx)\n", __func__, buffer, data_address, num_wrt_blks);
     // Check if the SD card pointer is valid
     if (NULL == sd_card_p)
         return SD_BLOCK_DEVICE_ERROR_PARAMETER;
@@ -1228,15 +1262,15 @@ static block_dev_err_t sd_write_blocks(sd_card_t *sd_card_p, uint8_t const buffe
 
     // If writing only one block, use the optimized function
     if (1 == num_wrt_blks) {
-        status = in_sd_write_block(sd_card_p, buffer, data_address);
+        status = write_block(sd_card_p, buffer, data_address);
     } else {
         // If writing multiple blocks, retry the operation until it succeeds or reaches the maximum number of retries
-        unsigned retries = SD_COMMAND_RETRIES;
+        unsigned retries = sd_timeouts.sd_command_retries;
         do {
-            if (retries < SD_COMMAND_RETRIES) DBG_PRINTF("Retrying\n");
+            if (retries < sd_timeouts.sd_command_retries) DBG_PRINTF("Retrying\n");
             status = in_sd_write_blocks(sd_card_p, &buffer, &data_address, &num_wrt_blks);
             if (SD_BLOCK_DEVICE_ERROR_WRITE == status)
-                DBG_PRINTF("status=0x%x data_address=%p num_wrt_blks=%lu\n", status, data_address, num_wrt_blks);
+                DBG_PRINTF("%s status=0x%x data_address=%lu num_wrt_blks=%lu\n", sd_get_drive_prefix(sd_card_p), status, data_address, num_wrt_blks);
         } while (SD_BLOCK_DEVICE_ERROR_WRITE == status && --retries && num_wrt_blks);
     }
 
@@ -1417,7 +1451,7 @@ static block_dev_err_t sd_init_medium(sd_card_t *sd_card_p) {
     uint32_t start = millis();
     do {
         status = sd_cmd(sd_card_p, ACMD41_SD_SEND_OP_COND, arg, true, &response);
-    } while (response & R1_IDLE_STATE && millis() - start < SD_COMMAND_TIMEOUT);
+    } while (response & R1_IDLE_STATE && millis() - start < sd_timeouts.sd_command);
     // Initialization complete: ACMD41 successful
     if ((SD_BLOCK_DEVICE_ERROR_NONE != status) || (0x00 != response)) {
         sd_card_p->state.card_type = CARD_UNKNOWN;
@@ -1492,7 +1526,7 @@ static bool sd_spi_test_com(sd_card_t *sd_card_p) {
         if (sd_wait_ready(sd_card_p, 0)) {
             // DO has been released, try to get status
             uint32_t response;
-            for (int i = 0; i < SD_COMMAND_RETRIES; i++) {
+            for (unsigned i = 0; i < sd_timeouts.sd_command_retries; i++) {
                 // Send command over SPI interface
                 response = sd_cmd_spi(sd_card_p, CMD13_SEND_STATUS, 0);
                 if (R1_NO_RESPONSE != response) {
@@ -1523,7 +1557,7 @@ static bool sd_spi_test_com(sd_card_t *sd_card_p) {
         if (sd_wait_ready(sd_card_p, 0)) {
             // DO has been released, try to make SD card go idle
             uint32_t response;
-            for (int i = 0; i < SD_COMMAND_RETRIES; i++) {
+            for (unsigned i = 0; i < sd_timeouts.sd_command_retries; i++) {
                 // Send command over SPI interface
                 response = sd_cmd_spi(sd_card_p, CMD0_GO_IDLE_STATE, 0);
                 if (R1_NO_RESPONSE != response) {
@@ -1545,10 +1579,7 @@ static bool sd_spi_test_com(sd_card_t *sd_card_p) {
 }
 
 /**
- * Initializes the SD card over SPI.
- *
- * @param sd_card_p Pointer to the SD card object.
- * @return The status of the SD card.
+ * @brief Initializes the SD card over SPI.
  *
  * This function initializes the SD card over SPI. It first checks if the SD card is already
  * initialized, and if so, it returns the current status. If the card is not initialized, it
@@ -1556,39 +1587,47 @@ static bool sd_spi_test_com(sd_card_t *sd_card_p) {
  * initialized by sending the initializing sequence, checking the card type, setting the SCK
  * for data transfer, and setting the block length to 512. The card is now considered initialized
  * and its status is returned.
+ *
+ * @param sd_card_p Pointer to the SD card object.
+ * @return The status of the SD card:
+ *  STA_NOINIT = 0x01, // Drive not initialized 
+ *  STA_NODISK = 0x02, // No medium in the drive
+ *  STA_PROTECT = 0x04 // Write protected
  */
-DSTATUS sd_spi_init(sd_card_t *sd_card_p) {
+DSTATUS sd_card_spi_init(sd_card_t *sd_card_p) {
     TRACE_PRINTF("> %s\n", __FUNCTION__);
 
-    //	STA_NOINIT = 0x01, /* Drive not initialized */
-    //	STA_NODISK = 0x02, /* No medium in the drive */
-    //	STA_PROTECT = 0x04 /* Write protected */
-
+    // Acquire the lock
     sd_lock(sd_card_p);
 
-    // Make sure there's a card in the socket before proceeding
+    // Check if there's a card in the socket before proceeding
     sd_card_detect(sd_card_p);
     if (sd_card_p->state.m_Status & STA_NODISK) {
+        // Release the lock and return the current status
         sd_unlock(sd_card_p);
         return sd_card_p->state.m_Status;
     }
-    // Make sure we're not already initialized before proceeding
+    // Check if we're not already initialized before proceeding
     if (!(sd_card_p->state.m_Status & STA_NOINIT)) {
+        // Release the lock and return the current status
         sd_unlock(sd_card_p);
         return sd_card_p->state.m_Status;
     }
+
     // Initialize the member variables
     sd_card_p->state.card_type = SDCARD_NONE;
 
+    // Acquire the SD card
     sd_spi_acquire(sd_card_p);
 
+    // Initialize the medium
     int err = sd_init_medium(sd_card_p);
     if (SD_BLOCK_DEVICE_ERROR_NONE != err) {
         EMSG_PRINTF("Failed to initialize card\n");
         sd_release(sd_card_p);
         return sd_card_p->state.m_Status;
     }
-    // No support for SDSC Card (CCS=0) with byte unit address:
+    // No support for SDSC Card (CCS=0) with byte unit address
     if (SDCARD_V2HC != sd_card_p->state.card_type) {
         EMSG_PRINTF("SD Standard Capacity Memory Card unsupported\n");
         sd_release(sd_card_p);
@@ -1600,25 +1639,26 @@ DSTATUS sd_spi_init(sd_card_t *sd_card_p) {
     // Set SCK for data transfer
     sd_spi_go_high_frequency(sd_card_p);
 
+    // Get the number of sectors on the card
     sd_card_p->state.sectors = in_sd_spi_sectors(sd_card_p);
     if (0 == sd_card_p->state.sectors) {
         // CMD9 failed
         sd_release(sd_card_p);
         return sd_card_p->state.m_Status;
     }
-    // CMD10, Response R2 (R1 byte + 16-byte block read)
+    // Get the CID of the card
     if (SD_BLOCK_DEVICE_ERROR_NONE != sd_cmd(sd_card_p, CMD10_SEND_CID, 0x0, false, 0)) {
         DBG_PRINTF("Didn't get a response from the disk\n");
         sd_release(sd_card_p);
         return sd_card_p->state.m_Status;
     }
-    if (sd_read_bytes(sd_card_p, (uint8_t *)&sd_card_p->state.CID, sizeof(CID_t)) != 0) {
+    if (read_bytes(sd_card_p, (uint8_t *)&sd_card_p->state.CID, sizeof(CID_t)) != 0) {
         DBG_PRINTF("Couldn't read CID response from disk\n");
         sd_release(sd_card_p);
         return sd_card_p->state.m_Status;
     }
 
-    // Set block length to 512 (CMD16)
+    // Set the block length to 512 (CMD16)
     if (SD_BLOCK_DEVICE_ERROR_NONE !=
         sd_cmd(sd_card_p, CMD16_SET_BLOCKLEN, sd_block_size, false, 0)) {
         DBG_PRINTF("Set %u-byte block timed out\n", sd_block_size);
@@ -1629,6 +1669,7 @@ DSTATUS sd_spi_init(sd_card_t *sd_card_p) {
     // The card is now initialized
     sd_card_p->state.m_Status &= ~STA_NOINIT;
 
+    // Release the SD card
     sd_release(sd_card_p);
 
     // Return the disk status
@@ -1668,7 +1709,7 @@ void sd_spi_ctor(sd_card_t *sd_card_p) {
     sd_card_p->write_blocks = sd_write_blocks;
     sd_card_p->read_blocks = sd_read_blocks;
     sd_card_p->sync = sd_sync;
-    sd_card_p->init = sd_spi_init;
+    sd_card_p->init = sd_card_spi_init;
     sd_card_p->deinit = sd_deinit;
     sd_card_p->get_num_sectors = sd_spi_sectors;
     sd_card_p->sd_test_com = sd_spi_test_com;

--- a/src/sd_driver/SPI/sd_spi.h
+++ b/src/sd_driver/SPI/sd_spi.h
@@ -16,8 +16,13 @@ specific language governing permissions and limitations under the License.
 
 #include <stdint.h>
 //
+#include "pico/stdlib.h"
+//
+#include "delays.h"
+#include "my_debug.h"
 #include "my_spi.h"
 #include "sd_card.h"
+#include "sd_timeouts.h"
 
 #ifdef NDEBUG
 #pragma GCC diagnostic ignored "-Wunused-variable"
@@ -34,23 +39,43 @@ void sd_spi_go_high_frequency(sd_card_t *this);
 
 /* 
 After power up, the host starts the clock and sends the initializing sequence on the CMD line. 
-This sequence is a contiguous stream of logical ‘1’s. The sequence length is the maximum of 1msec, 
-74 clocks or the supply-ramp-uptime; the additional 10 clocks 
-(over the 64 clocks after what the card should be ready for communication) is
-provided to eliminate power-up synchronization problems. 
+This sequence is a contiguous stream of logical ‘1’s. The sequence length is the maximum of
+1msec, 74 clocks or the supply-ramp-uptime; the additional 10 clocks (over the 64 clocks after
+what the card should be ready for communication) is provided to eliminate power-up
+synchronization problems.
 */
-void sd_spi_send_initializing_sequence(sd_card_t * sd_card_p);
+void sd_spi_send_initializing_sequence(sd_card_t *sd_card_p);
 
-static inline uint8_t sd_spi_write(sd_card_t *sd_card_p, const uint8_t value) {
-    // TRACE_PRINTF("%s\n", __FUNCTION__);
+static inline uint8_t sd_spi_read(sd_card_t *sd_card_p) {
     uint8_t received = SPI_FILL_CHAR;
-#if 1
+    uint32_t start = millis();
+    while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
+           millis() - start < sd_timeouts.sd_spi_read)
+        tight_loop_contents();
+    myASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
+    int num = spi_read_blocking(sd_card_p->spi_if_p->spi->hw_inst, SPI_FILL_CHAR, &received, 1);
+    myASSERT(1 == num);
+    return received;
+}
+
+static inline void sd_spi_write(sd_card_t *sd_card_p, const uint8_t value) {
+    uint32_t start = millis();
+    while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
+           millis() - start < sd_timeouts.sd_spi_write)
+        tight_loop_contents();
+    myASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
+    int num = spi_write_blocking(sd_card_p->spi_if_p->spi->hw_inst, &value, 1);
+    myASSERT(1 == num);
+}
+static inline uint8_t sd_spi_write_read(sd_card_t *sd_card_p, const uint8_t value) {
+    uint8_t received = SPI_FILL_CHAR;
+    uint32_t start = millis();
+    while (!spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst) &&
+           millis() - start < sd_timeouts.sd_spi_write_read)
+        tight_loop_contents();
+    myASSERT(spi_is_writable(sd_card_p->spi_if_p->spi->hw_inst));
     int num = spi_write_read_blocking(sd_card_p->spi_if_p->spi->hw_inst, &value, &received, 1);    
-    assert(1 == num);
-#else
-    bool success = spi_transfer(sd_card_p->spi_if_p->spi, &value, &received, 1);
-    assert(success);
-#endif
+    myASSERT(1 == num);
     return received;
 }
 
@@ -74,19 +99,9 @@ static inline void sd_spi_deselect(sd_card_t *sd_card_p) {
     */
     sd_spi_write(sd_card_p, SPI_FILL_CHAR);
 }
-/* Some SD cards want to be deselected between every bus transaction */
-static inline void sd_spi_deselect_pulse(sd_card_t *sd_card_p) {
-    sd_spi_deselect(sd_card_p);
-    // tCSH Pulse duration, CS high 200 ns
-    sd_spi_select(sd_card_p);
-}
 
-static inline void sd_spi_lock(sd_card_t *sd_card_p) {
-    spi_lock(sd_card_p->spi_if_p->spi);
-}
-static inline void sd_spi_unlock(sd_card_t *sd_card_p) {
-   spi_unlock(sd_card_p->spi_if_p->spi);
-}
+static inline void sd_spi_lock(sd_card_t *sd_card_p) { spi_lock(sd_card_p->spi_if_p->spi); }
+static inline void sd_spi_unlock(sd_card_t *sd_card_p) { spi_unlock(sd_card_p->spi_if_p->spi); }
 
 static inline void sd_spi_acquire(sd_card_t *sd_card_p) {
     sd_spi_lock(sd_card_p);
@@ -99,13 +114,15 @@ static inline void sd_spi_release(sd_card_t *sd_card_p) {
 
 /* Transfer tx to SPI while receiving SPI to rx.
 tx or rx can be NULL if not important. */
-static inline void sd_spi_transfer_start(sd_card_t *sd_card_p, const uint8_t *tx, uint8_t *rx, size_t length) {
+static inline void sd_spi_transfer_start(sd_card_t *sd_card_p, const uint8_t *tx, uint8_t *rx,
+                                         size_t length) {
     return spi_transfer_start(sd_card_p->spi_if_p->spi, tx, rx, length);
 }
 static inline bool sd_spi_transfer_wait_complete(sd_card_t *sd_card_p, uint32_t timeout_ms) {
     return spi_transfer_wait_complete(sd_card_p->spi_if_p->spi, timeout_ms);
 }
-static inline bool sd_spi_transfer(sd_card_t *sd_card_p, const uint8_t *tx, uint8_t *rx, size_t length) {
+static inline bool sd_spi_transfer(sd_card_t *sd_card_p, const uint8_t *tx, uint8_t *rx,
+                                   size_t length) {
 	return spi_transfer(sd_card_p->spi_if_p->spi, tx, rx, length);
 }
 

--- a/src/sd_driver/sd_card.c
+++ b/src/sd_driver/sd_card.c
@@ -27,6 +27,7 @@ specific language governing permissions and limitations under the License.
 #include "my_debug.h"
 #include "sd_card_constants.h"
 #include "sd_regs.h"
+#include "sd_timeouts.h"
 #include "util.h"
 //
 #include "diskio.h" /* Declarations of disk functions */  // Needed for STA_NOINIT, ...

--- a/src/sd_driver/sd_card_constants.h
+++ b/src/sd_driver/sd_card_constants.h
@@ -46,8 +46,10 @@ typedef enum {
     CARD_UNKNOWN = 4 /**< Unknown or unsupported card */
 } card_type_t;
 
+/* On the wire, convert to hex and add 0x40 for transmitter bit.
+e.g.: CMD17_READ_SINGLE_BLOCK: 17 = 0x11; 0x11 | 0x40 = 0x51 */
 // Supported SD Card Commands
-typedef enum {
+typedef enum {                          /* Number on wire in parens */
     CMD_NOT_SUPPORTED = -1,             /* Command not supported error */
     CMD0_GO_IDLE_STATE = 0,             /* Resets the SD Memory Card */
     CMD1_SEND_OP_COND = 1,              /* Sends host capacity support */
@@ -59,13 +61,13 @@ typedef enum {
     CMD9_SEND_CSD = 9,                  /* Provides Card Specific data */
     CMD10_SEND_CID = 10,                /* Provides Card Identification */
     CMD12_STOP_TRANSMISSION = 12,       /* Forces the card to stop transmission */
-    CMD13_SEND_STATUS = 13,             /* Card responds with status */
+    CMD13_SEND_STATUS = 13,             /* (0x4D) Card responds with status */
     CMD16_SET_BLOCKLEN = 16,            /* Length for SC card is set */
-    CMD17_READ_SINGLE_BLOCK = 17,       /* Read single block of data */
-    CMD18_READ_MULTIPLE_BLOCK = 18,     /* Card transfers data blocks to host
+    CMD17_READ_SINGLE_BLOCK = 17,       /* (0x51) Read single block of data */
+    CMD18_READ_MULTIPLE_BLOCK = 18,     /* (0x52) Continuously Card transfers data blocks to host
          until interrupted by a STOP_TRANSMISSION command */
-    CMD24_WRITE_BLOCK = 24,             /* Write single block of data */
-    CMD25_WRITE_MULTIPLE_BLOCK = 25,    /* Continuously writes blocks of data
+    CMD24_WRITE_BLOCK = 24,             /* (0x58) Write single block of data */
+    CMD25_WRITE_MULTIPLE_BLOCK = 25,    /* (0x59) Continuously writes blocks of data
         until    'Stop Tran' token is sent */
     CMD27_PROGRAM_CSD = 27,             /* Programming bits of CSD */
     CMD32_ERASE_WR_BLK_START_ADDR = 32, /* Sets the address of the first write

--- a/src/src/crash.c
+++ b/src/src/crash.c
@@ -16,6 +16,7 @@ specific language governing permissions and limitations under the License.
 #include <time.h>
 //
 #include "pico/stdlib.h"
+#include "RP2040.h"
 //
 #include "crc.h"
 #include "my_debug.h"
@@ -24,6 +25,10 @@ specific language governing permissions and limitations under the License.
 //
 #include "crash.h"
 
+#if defined(NDEBUG) || !USE_DBG_PRINTF
+#  pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
 static volatile crash_info_t crash_info_ram __attribute__((section(".uninitialized_data")));
 
 static crash_info_t volatile *crash_info_ram_p = &crash_info_ram;
@@ -31,7 +36,7 @@ static crash_info_t volatile *crash_info_ram_p = &crash_info_ram;
 static crash_info_t previous_crash_info;
 static bool _previous_crash_info_valid = false;
 
-__attribute__((noreturn))
+__attribute__((noreturn, always_inline))
 static inline void reset() {
 //    if (debugger_connected()) {
         __breakpoint();
@@ -111,14 +116,14 @@ __attribute__((used)) extern void DebugMon_HandlerC(uint32_t const *faultStackAd
     crash_info_ram.timestamp = epochtime;
 
     /* Stores general registers */
-    crash_info_ram.cy_faultFrame.r0 = faultStackAddr[CY_R0_Pos];
-    crash_info_ram.cy_faultFrame.r1 = faultStackAddr[CY_R1_Pos];
-    crash_info_ram.cy_faultFrame.r2 = faultStackAddr[CY_R2_Pos];
-    crash_info_ram.cy_faultFrame.r3 = faultStackAddr[CY_R3_Pos];
-    crash_info_ram.cy_faultFrame.r12 = faultStackAddr[CY_R12_Pos];
-    crash_info_ram.cy_faultFrame.lr = faultStackAddr[CY_LR_Pos];
-    crash_info_ram.cy_faultFrame.pc = faultStackAddr[CY_PC_Pos];
-    crash_info_ram.cy_faultFrame.psr = faultStackAddr[CY_PSR_Pos];
+    crash_info_ram.cy_faultFrame.r0 = faultStackAddr[R0_Pos];
+    crash_info_ram.cy_faultFrame.r1 = faultStackAddr[R1_Pos];
+    crash_info_ram.cy_faultFrame.r2 = faultStackAddr[R2_Pos];
+    crash_info_ram.cy_faultFrame.r3 = faultStackAddr[R3_Pos];
+    crash_info_ram.cy_faultFrame.r12 = faultStackAddr[R12_Pos];
+    crash_info_ram.cy_faultFrame.lr = faultStackAddr[LR_Pos];
+    crash_info_ram.cy_faultFrame.pc = faultStackAddr[PC_Pos];
+    crash_info_ram.cy_faultFrame.psr = faultStackAddr[PSR_Pos];
     ///* Stores the Configurable Fault Status Register state with the fault cause */
     //crash_info_ram.cy_faultFrame.cfsr.cfsrReg = SCB->CFSR;
     ///* Stores the Hard Fault Status Register */
@@ -167,14 +172,14 @@ void Hardfault_HandlerC(uint32_t const *faultStackAddr) {
     crash_info_ram.timestamp = epochtime;
 
     /* Stores general registers */
-    crash_info_ram.cy_faultFrame.r0 = faultStackAddr[CY_R0_Pos];
-    crash_info_ram.cy_faultFrame.r1 = faultStackAddr[CY_R1_Pos];
-    crash_info_ram.cy_faultFrame.r2 = faultStackAddr[CY_R2_Pos];
-    crash_info_ram.cy_faultFrame.r3 = faultStackAddr[CY_R3_Pos];
-    crash_info_ram.cy_faultFrame.r12 = faultStackAddr[CY_R12_Pos];
-    crash_info_ram.cy_faultFrame.lr = faultStackAddr[CY_LR_Pos];
-    crash_info_ram.cy_faultFrame.pc = faultStackAddr[CY_PC_Pos];
-    crash_info_ram.cy_faultFrame.psr = faultStackAddr[CY_PSR_Pos];
+    crash_info_ram.cy_faultFrame.r0 = faultStackAddr[R0_Pos];
+    crash_info_ram.cy_faultFrame.r1 = faultStackAddr[R1_Pos];
+    crash_info_ram.cy_faultFrame.r2 = faultStackAddr[R2_Pos];
+    crash_info_ram.cy_faultFrame.r3 = faultStackAddr[R3_Pos];
+    crash_info_ram.cy_faultFrame.r12 = faultStackAddr[R12_Pos];
+    crash_info_ram.cy_faultFrame.lr = faultStackAddr[LR_Pos];
+    crash_info_ram.cy_faultFrame.pc = faultStackAddr[PC_Pos];
+    crash_info_ram.cy_faultFrame.psr = faultStackAddr[PSR_Pos];
 
     crash_info_ram.xor_checksum =
         crc7((uint8_t *)&crash_info_ram, offsetof(crash_info_t, xor_checksum));
@@ -261,11 +266,6 @@ int dump_crash_info(crash_info_t const *const crash_info_p, int next, char *cons
                               (void *)crash_info_p->cy_faultFrame.pc);
             next = 0;
             break;
-        //case crash_info_task_name:
-        //    nwrit += snprintf(buf + nwrit, buf_sz - nwrit, "\tTask Name: %s\n",
-        //                      crash_info_p->task_name);
-        //    next = 0;
-        //    break;
         case crash_info_reset_request_line:
             nwrit +=
                 snprintf(buf + nwrit, buf_sz - nwrit, "\tReset request calling function: %s\n",

--- a/src/src/crc.c
+++ b/src/src/crc.c
@@ -334,7 +334,7 @@ static inline uint16_t swaplow(uint16_t crc) {
 
 // This code assumes that integers are stored little-endian.
 
-__attribute__((optimize("O3")))
+__attribute__((optimize("Ofast")))
 static uint16_t crc16ibm_3740_word(uint16_t crc, void const *mem, size_t len) {
     unsigned char const *data = mem;
     if (data == NULL)
@@ -368,8 +368,7 @@ static uint16_t crc16ibm_3740_word(uint16_t crc, void const *mem, size_t len) {
     return crc;
 }
 
-
-unsigned short crc16(uint8_t* data, int length)
+uint16_t crc16(uint8_t const *data, int const length)
 {
 	//Calculate the CRC16 checksum for the specified data block
 	unsigned short crc = 0;

--- a/src/src/file_stream.c
+++ b/src/src/file_stream.c
@@ -31,7 +31,7 @@ static ssize_t cookie_read_function(void *vcookie_p, char *buf, size_t n) {
     UINT br;
     FRESULT fr = f_read(file_p, buf, n, &br);
     if (FR_OK != fr) {
-        printf("f_read error: %s\n", FRESULT_str(fr));
+        DBG_PRINTF("f_read error: %s\n", FRESULT_str(fr));
         return -1;
     }
     return br;
@@ -45,7 +45,7 @@ static ssize_t cookie_write_function(void *vcookie_p, const char *buf, size_t n)
     UINT bw;
     FRESULT fr = f_write(file_p, buf, n, &bw);
     if (FR_OK != fr) {
-        printf("f_read error: %s\n", FRESULT_str(fr));
+        DBG_PRINTF("f_read error: %s\n", FRESULT_str(fr));
         return -1;
     }
     return bw;
@@ -74,7 +74,7 @@ static int cookie_seek_function(void *vcookie_p, off_t *off, int whence) {
             ASSERT_CASE_NOT(whence);
     }
     if (FR_OK != fr) {
-        printf("f_lseek error: %s\n", FRESULT_str(fr));
+        DBG_PRINTF("f_lseek error: %s\n", FRESULT_str(fr));
         return -1;
     } else {
         *off = f_tell(file_p);
@@ -91,7 +91,7 @@ static int cookie_close_function(void *vcookie_p) {
     FRESULT fr = f_close(file_p);
     free(vcookie_p);
     if (FR_OK != fr) {
-        printf("f_close error: %s\n", FRESULT_str(fr));
+        DBG_PRINTF("f_close error: %s\n", FRESULT_str(fr));
         return -1;
     } else {
         return 0;
@@ -126,7 +126,7 @@ FILE *open_file_stream(const char *pathname, const char *pcMode) {
 
     FRESULT fr = f_open(&cookie_p->file, pathname, mode);
     if (FR_OK != fr) {
-        printf("f_lseek error: %s\n", FRESULT_str(fr));
+        DBG_PRINTF("f_lseek error: %s\n", FRESULT_str(fr));
         return NULL;
     }
     cookie_io_functions_t iofs = {cookie_read_function, cookie_write_function,

--- a/src/src/my_debug.c
+++ b/src/src/my_debug.c
@@ -44,7 +44,8 @@ void __attribute__((weak)) put_out_debug_message(const char *s) { (void)s; }
 
 #if defined(USE_PRINTF) && USE_PRINTF
 
-int __attribute__((weak)) error_message_printf(const char *func, int line, 
+int __attribute__((weak)) 
+error_message_printf(const char *func, int line, 
         const char *fmt, ...) 
 {
     printf("%s:%d: ", func, line);
@@ -52,8 +53,7 @@ int __attribute__((weak)) error_message_printf(const char *func, int line,
     va_start(args, fmt);
     int cw = vprintf(fmt, args);
     va_end(args);
-    // stdio_flush();
-    fflush(stdout);
+    stdio_flush();
     return cw;
 }
 int __attribute__((weak)) error_message_printf_plain(const char *fmt, ...) {
@@ -61,8 +61,7 @@ int __attribute__((weak)) error_message_printf_plain(const char *fmt, ...) {
     va_start(args, fmt);
     int cw = vprintf(fmt, args);
     va_end(args);
-    // stdio_flush();
-    fflush(stdout);
+    stdio_flush();
     return cw;
 }
 int __attribute__((weak)) info_message_printf(const char *fmt, ...) {
@@ -72,7 +71,8 @@ int __attribute__((weak)) info_message_printf(const char *fmt, ...) {
     va_end(args);
     return cw;
 }
-int __attribute__((weak)) debug_message_printf(const char *func, int line,  
+int __attribute__((weak)) 
+debug_message_printf(const char *func, int line, 
         const char *fmt, ...) 
 {
 #if defined(NDEBUG) || !USE_DBG_PRINTF
@@ -83,8 +83,7 @@ int __attribute__((weak)) debug_message_printf(const char *func, int line,
     va_start(args, fmt);
     int cw = vprintf(fmt, args);
     va_end(args);
-    // stdio_flush();
-    fflush(stdout);
+    stdio_flush();
     return cw;
 }
 
@@ -92,7 +91,8 @@ int __attribute__((weak)) debug_message_printf(const char *func, int line,
 
 /* These will truncate at 256 bytes. You can tell by checking the return code. */
 
-int __attribute__((weak)) error_message_printf(const char *func, int line,  
+int __attribute__((weak)) 
+error_message_printf(const char *func, int line, 
         const char *fmt, ...) 
 {
     char buf[256] = {0};
@@ -121,7 +121,8 @@ int __attribute__((weak)) info_message_printf(const char *fmt, ...) {
     va_end(args);
     return cw;
 }
-int __attribute__((weak)) debug_message_printf(const char *func, int line,  
+int __attribute__((weak)) 
+debug_message_printf(const char *func, int line, 
         const char *fmt, ...) 
 {
     char buf[256] = {0};
@@ -150,7 +151,6 @@ void assert_case_not_func(const char *file, int line, const char *func, int v) {
 }
 
 void assert_case_is(const char *file, int line, const char *func, int v, int expected) {
-    TRIG();  // DEBUG
     char pred[128];
     snprintf(pred, sizeof pred, "%d is %d", v, expected);
     my_assert_func(file, line, func, pred);
@@ -169,7 +169,7 @@ void dump8buf(char *buf, size_t buf_sz, uint8_t *pbytes, size_t nbytes) {
 }
 void hexdump_8(const char *s, const uint8_t *pbytes, size_t nbytes) {
     IMSG_PRINTF("\n%s(%s, 0x%p, %zu)\n", __FUNCTION__, s, pbytes, nbytes);
-    fflush(stdout);
+    stdio_flush();
     size_t col = 0;
     for (size_t byte_ix = 0; byte_ix < nbytes; ++byte_ix) {
         IMSG_PRINTF("%02hhx ", pbytes[byte_ix]);
@@ -177,13 +177,13 @@ void hexdump_8(const char *s, const uint8_t *pbytes, size_t nbytes) {
             IMSG_PRINTF("\n");
             col = 0;
         }
-        fflush(stdout);
+        stdio_flush();
     }
 }
 // nwords is size in WORDS!
 void hexdump_32(const char *s, const uint32_t *pwords, size_t nwords) {
     IMSG_PRINTF("\n%s(%s, 0x%p, %zu)\n", __FUNCTION__, s, pwords, nwords);
-    fflush(stdout);
+    stdio_flush();
     size_t col = 0;
     for (size_t word_ix = 0; word_ix < nwords; ++word_ix) {
         IMSG_PRINTF("%08lx ", pwords[word_ix]);
@@ -191,7 +191,7 @@ void hexdump_32(const char *s, const uint32_t *pwords, size_t nwords) {
             IMSG_PRINTF("\n");
             col = 0;
         }
-        fflush(stdout);
+        stdio_flush();
     }
 }
 // nwords is size in bytes

--- a/src/src/sd_timeouts.c
+++ b/src/src/sd_timeouts.c
@@ -1,0 +1,19 @@
+
+#include "sd_timeouts.h"
+
+sd_timeouts_t sd_timeouts __attribute__((weak)) = {
+    .sd_command = 2000, // Timeout in ms for response
+    .sd_command_retries = 3, // Times SPI cmd is retried when there is no response
+    .sd_lock = 8000, // Timeout in ms for response
+    .sd_spi_read = 1000, // Timeout in ms for response
+    .sd_spi_write = 1000, // Timeout in ms for response
+    .sd_spi_write_read = 1000, // Timeout in ms for response
+    .spi_lock = 4000, // Timeout in ms for response
+    .rp2040_sdio_command_R1 = 5, // Timeout in ms for response
+    .rp2040_sdio_command_R2 = 2, // Timeout in ms for response
+    .rp2040_sdio_command_R3 = 2, // Timeout in ms for response
+    .rp2040_sdio_rx_poll = 1000, // Timeout in ms for response
+    .rp2040_sdio_tx_poll = 5000, // Timeout in ms for response
+    .sd_sdio_begin = 1000, // Timeout in ms for response
+    .sd_sdio_stopTransmission = 200, // Timeout in ms for response
+};


### PR DESCRIPTION
* Add `spi_mode` to the hardware configuration.
For SPI attached cards, SPI Mode 3 can significantly improve performance.
See [SPI Controller Configuration](#spi-controller-configuration).
* Make timeouts configurable. See [Timeouts](#timeouts).
* Add retries in SPI driver `sd_read_blocks`.