### PR TITLE
Port to RP2350 RISC-V mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,11 +34,19 @@ target_include_directories(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico INTERFACE
     sd_driver
     include
 )
+
+if(PICO_RISCV)
+    set(HWDEP_LIBS hardware_watchdog)
+else()
+    set(HWDEP_LIBS cmsis_core)
+endif()
+
 target_link_libraries(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico INTERFACE
     hardware_dma
     hardware_pio
     hardware_spi
+    hardware_sync
     pico_aon_timer
     pico_stdlib
-    cmsis_core
+    ${HWDEP_LIBS}
 )

--- a/src/include/delays.h
+++ b/src/include/delays.h
@@ -50,22 +50,17 @@ call to millis() returns 0xFFFFFFFF:
 
 #include <stdint.h>
 //
+#include "pico.h"
 #include "pico/stdlib.h"
-#if PICO_RP2040
-#  include "RP2040.h"
-#endif
-#if PICO_RP2350
-#  include "RP2350.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 static inline uint32_t millis() {
-    __COMPILER_BARRIER();
+    __compiler_memory_barrier();
     return time_us_64() / 1000;
-    __COMPILER_BARRIER();
+    __compiler_memory_barrier();
 }
 
 static inline void delay_ms(uint32_t ulTime_ms) {
@@ -73,9 +68,9 @@ static inline void delay_ms(uint32_t ulTime_ms) {
 }
 
 static inline uint64_t micros() {
-    __COMPILER_BARRIER();
+    __compiler_memory_barrier();
     return to_us_since_boot(get_absolute_time());
-    __COMPILER_BARRIER();
+    __compiler_memory_barrier();
 }
 
 #ifdef __cplusplus

--- a/src/sd_driver/SDIO/rp2040_sdio.c
+++ b/src/sd_driver/SDIO/rp2040_sdio.c
@@ -15,10 +15,13 @@
 #include "hardware/dma.h"
 #include "hardware/gpio.h"
 #include "hardware/pio.h"
-#if PICO_RP2040
-#include "RP2040.h"
-#else
-#include "RP2350.h"
+#if !PICO_RISCV
+#  if PICO_RP2040
+#    include "RP2040.h"
+#  endif
+#  if PICO_RP2350
+#    include "RP2350.h"
+#  endif
 #endif
 //
 #include "dma_interrupts.h"
@@ -686,11 +689,13 @@ void sdio_irq_handler(sd_card_t *sd_card_p) {
 // Check if transmission is complete
 sdio_status_t rp2040_sdio_tx_poll(sd_card_t *sd_card_p, uint32_t *bytes_complete)
 {
+#if !PICO_RISCV
     if (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk)
     {
         // Verify that IRQ handler gets called even if we are in hardfault handler
         sdio_irq_handler(sd_card_p);
     }
+#endif
 
     if (bytes_complete)
     {

--- a/src/src/my_debug.c
+++ b/src/src/my_debug.c
@@ -19,13 +19,8 @@ specific language governing permissions and limitations under the License.
 #include <string.h>
 #include <time.h>
 //
-#if PICO_RP2040
-#  include "RP2040.h"
-#endif
-#if PICO_RP2350
-#  include "RP2350.h"
-#endif
 #include "pico/stdlib.h"
+#include "hardware/sync.h"
 //
 #include "crash.h"
 //
@@ -145,7 +140,7 @@ void __attribute__((weak)) my_assert_func(const char *file, int line, const char
                                           const char *pred) {
     error_message_printf_plain("assertion \"%s\" failed: file \"%s\", line %d, function: %s\n",
                                pred, file, line, func);
-    __disable_irq(); /* Disable global interrupts. */
+    (void)save_and_disable_interrupts(); /* Disable global interrupts. */
     capture_assert(file, line, func, pred);
 }
 


### PR DESCRIPTION
Use Pico SDK APIs instead of ARM CMSIS ones:
__COMPILER_BARRIER() -> __compiler_memory_barrier()
__DSB() -> __dsb()
__disable_irq() -> save_and_disable_interrupts()

Use watchdog_reboot() in reset() on RISC-V.

rp2040_sdio_tx_poll(): I couldn't find any way to determine if we are in an interrupt/exception-handler on RISC-V, so only do this on ARM.

Disable ARM specfic DebugMon_Handler()/isr_hardfault() on RISC-V for now.