### PR TITLE
sd_read_blocks error path: release locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
-# v3.6.0
+# v3.6.1
 
 ## C/C++ Library for SD Cards on the Pico
 
@@ -11,6 +11,9 @@ and a 4-bit wide Secure Digital Input Output (SDIO) driver derived from
 It is wrapped up in a complete runnable project, with a little command line interface, some self tests, and an example data logging application.
 
 ## What's new
+### v3.6.1
+Fix failure to release locks when an error occurs while reading blocks and CMD12_STOP_TRANSMISSION also fails.
+This could happen, for example, if the SD card falls out after it has been mounted.
 ### v3.6.0
 Add `examples/usb_mass_storage` example which connects a Pico's USB mass storage (MSC) interface to an SD card,
 effectively turning it into an SD card USB dongle.

--- a/examples/command_line/src/command.cpp
+++ b/examples/command_line/src/command.cpp
@@ -371,6 +371,8 @@ static void run_cat(const size_t argc, const char *argv[]) {
     while (f_gets(buf, sizeof buf, &fil)) {
         printf("%s", buf);
     }
+    if f_error(&fil)
+        printf("f_gets error\n");
     fr = f_close(&fil);
     if (FR_OK != fr) printf("f_close error: %s (%d)\n", FRESULT_str(fr), fr);
 }

--- a/src/sd_driver/SPI/sd_card_spi.c
+++ b/src/sd_driver/SPI/sd_card_spi.c
@@ -901,8 +901,8 @@ static block_dev_err_t sd_read_blocks(sd_card_t *sd_card_p, uint8_t *buffer,
         status = in_sd_read_blocks(sd_card_p, buffer, data_address, num_rd_blks);
         if (status != SD_BLOCK_DEVICE_ERROR_NONE) {
             if (SD_BLOCK_DEVICE_ERROR_NONE !=
-                sd_cmd(sd_card_p, CMD12_STOP_TRANSMISSION, 0x0, false, 0))
-                return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
+                    sd_cmd(sd_card_p, CMD12_STOP_TRANSMISSION, 0x0, false, 0))
+                break;
         }
     } while (--retries && status != SD_BLOCK_DEVICE_ERROR_NONE);
     sd_release(sd_card_p);


### PR DESCRIPTION
Relevant to #77, _Should locks be released on f_open errors_