### PR TITLE
fix: compiler diagnostics in crc16

### DIFF
--- a/src/include/crc.h
+++ b/src/include/crc.h
@@ -66,7 +66,7 @@ extern const char m_Crc7Table[];
  * @param length The length of the data block in bytes.
  * @return The calculated checksum.
  */
-uint16_t crc16(uint8_t const *data, int const length);
+uint16_t crc16(uint8_t const *data, size_t length);
 
 #endif
 

--- a/src/src/crc.c
+++ b/src/src/crc.c
@@ -368,7 +368,7 @@ static uint16_t crc16ibm_3740_word(uint16_t crc, void const *mem, size_t len) {
     return crc;
 }
 
-uint16_t crc16(uint8_t const *data, int const length)
+uint16_t crc16(uint8_t const *data, size_t length)
 {
 	//Calculate the CRC16 checksum for the specified data block
 	unsigned short crc = 0;


### PR DESCRIPTION
Fix compiler diagnostics for crc16, length argument.

Previously the argument was signed (int) but was used with unsigned (size_t) arguments in chk_crc16() and send_block() .
However length was supplied unchanged to crc16ibm_3740_word() which already uses size_t as argument type for length.
