### PR TITLE
fix SDIO ACMD41 cold boot failure in sd_sdio_begin()

### DIFF
--- a/src/sd_driver/SDIO/sd_card_sdio.c
+++ b/src/sd_driver/SDIO/sd_card_sdio.c
@@ -128,7 +128,8 @@ bool sd_sdio_begin(sd_card_t *sd_card_p)
             !checkReturnOk(rp2040_sdio_command_R3(sd_card_p, ACMD41_SD_SEND_OP_COND, 0xD0040000, &STATE.ocr))) // 3.0V voltage
             // !checkReturnOk(rp2040_sdio_command_R1(sd_card_p, ACMD41, 0xC0100000, &STATE.ocr)))
         {
-            return false;
+            delay_ms(1);
+            continue;
         }
 
         if ((uint32_t)(millis() - start) > sd_timeouts.sd_sdio_begin)


### PR DESCRIPTION
The ACMD41 polling loop in sd_sdio_begin() returned immediately on CMD55/ACMD41 command errors instead of retrying within the existing 1000ms timeout. On cold boot, cards that respond to CMD0/CMD8 may not yet be ready for ACMD41 (~20-30ms after power-up). The loop was designed to poll until OCR bit 31 indicates ready, but command errors short-circuited the retry logic.

Changed `return false` to `continue` so transient ACMD41 failures are retried within the sd_sdio_begin timeout, matching the SD specification's required polling behavior.